### PR TITLE
efs: Make bhd_directories take the processor generation optionally.

### DIFF
--- a/src/efs.rs
+++ b/src/efs.rs
@@ -1665,10 +1665,4 @@ impl<
 		self.ensure_no_overlap(Location::from(beginning), Location::from(end))?;
 		bhd_directory.create_subdirectory(beginning, end)
 	}*/
-
-	/// If the result is unique, returns the processor generation this
-	/// Embedded Firmware is for.
-	pub fn processor_generation(&self) -> Option<ProcessorGeneration> {
-		self.efh.processor_generation()
-	}
 }

--- a/src/ondisk.rs
+++ b/src/ondisk.rs
@@ -15,7 +15,6 @@ use crate::struct_accessors::Getter;
 use crate::struct_accessors::Setter;
 use crate::struct_accessors::DummyErrorChecks;
 use strum_macros::EnumString;
-use strum::IntoEnumIterator;
 use zerocopy::{AsBytes, FromBytes, LayoutVerified, Unaligned, U32, U64};
 //use crate::configs;
 
@@ -306,17 +305,6 @@ impl Efh {
 				0xffff_fffe & !(1 << generation)
 			}
 		}
-	}
-
-	/// If the result is unique, returns the processor generation this
-	/// Embedded Firmware is for.
-	pub fn processor_generation(&self) -> Option<ProcessorGeneration> {
-		for v in ProcessorGeneration::iter() {
-			if Self::efs_generations_for_processor_generation(v) == self.efs_generations.get() {
-				return Some(v);
-			}
-		}
-		None
 	}
 }
 


### PR DESCRIPTION
Previously, bhd_directories would always return a global list of all the directories in the flash. That is sometimes good (for collision check) and sometimes bad (at all other times).

Therefore, add an optional processor_generation parameter to be able to limit it to just the one directory you actually want.