### PR TITLE
lib: Add preferred_efh_location, and only accept that on Efs::create.

### DIFF
--- a/src/efs.rs
+++ b/src/efs.rs
@@ -1039,6 +1039,13 @@ impl<
 	}
 }
 
+pub const fn preferred_efh_location(processor_generation: ProcessorGeneration) -> Location {
+	match processor_generation {
+		ProcessorGeneration::Naples => 0x2_0000,
+		ProcessorGeneration::Rome | ProcessorGeneration::Milan => 0xFA_0000,
+	}
+}
+
 // TODO: Borrow storage.
 pub struct Efs<
 	T: FlashRead<ERASABLE_BLOCK_SIZE> + FlashWrite<ERASABLE_BLOCK_SIZE>,
@@ -1154,7 +1161,10 @@ impl<
 		efh_beginning: Location,
 		amd_physical_mode_mmio_size: Option<u32>,
 	) -> Result<Self> {
-		if !EFH_POSITION.contains(&efh_beginning) {
+		if !EFH_POSITION.contains(&efh_beginning) ||
+			preferred_efh_location(processor_generation) !=
+				efh_beginning
+		{
 			return Err(Error::EfsRangeCheck);
 		}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub use types::Error;
 pub use types::Result;
 pub use types::ValueOrLocation;
 pub use crate::efs::DirectoryFrontend;
+pub use crate::efs::preferred_efh_location;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This allows only putting the embedded firmware header at the *preferred* location for that processor generation.

AMD has a number of locations it would accept per generation.

Our possibilities are:

(1) only accept creating the embedded firmware header the preferred location, or
(2) make amd-efs blacklist the other locations for all flash operations so they won't accidentially store the correct signature even though they aren't an embedded firmware header.

This one chooses (1). If needed, we can do (2) later.