### PR TITLE
ondisk: Make ProcessorGeneration enum exhaustive on the Rust side.

### DIFF
--- a/src/ondisk.rs
+++ b/src/ondisk.rs
@@ -248,7 +248,6 @@ impl Default for Efh {
 #[repr(i8)]
 #[derive(Debug, PartialEq, FromPrimitive, Clone, Copy, EnumString, serde::Deserialize, serde::Serialize, strum_macros::EnumIter)]
 #[cfg_attr(feature = "std", derive(schemars::JsonSchema))]
-#[non_exhaustive]
 pub enum ProcessorGeneration {
 	Naples = -1,
 	Rome = 0,


### PR DESCRIPTION
Previously, we had `ProcessorGeneration` non-exhaustive.

That means that all our users have to have a default case in any `match`es.

On further thought, that isn't such a good idea.

If we add a new `ProcessorGeneration` variant, I'd actually prefer the user programs to fail to compile, not fail at runtime, if they have a `match` somewhere and it doesn't list the new generation.
