### PR TITLE
Cargo: Introduce new features "serde" and "schemars".

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,5 @@ zerocopy = "0.6"
 [features]
 default = []
 std = []
+serde = []
+schemars = ["std", "serde"]

--- a/src/ondisk.rs
+++ b/src/ondisk.rs
@@ -49,8 +49,9 @@ pub const EFH_POSITION: [Location; 6] = [
 ];
 
 #[repr(u8)]
-#[derive(Debug, PartialEq, FromPrimitive, ToPrimitive, Clone, Copy, serde::Deserialize, serde::Serialize)]
-#[cfg_attr(feature = "std", derive(schemars::JsonSchema))]
+#[derive(Debug, PartialEq, FromPrimitive, ToPrimitive, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub enum SpiReadMode {
 	Normal33_33Mhz = 0b000, // up to 33.33 MHz
@@ -64,8 +65,9 @@ pub enum SpiReadMode {
 }
 
 #[repr(u8)]
-#[derive(Debug, PartialEq, FromPrimitive, ToPrimitive, Clone, Copy, serde::Deserialize, serde::Serialize)]
-#[cfg_attr(feature = "std", derive(schemars::JsonSchema))]
+#[derive(Debug, PartialEq, FromPrimitive, ToPrimitive, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub enum SpiFastSpeedNew {
 	_66_66MHz = 0,
@@ -110,8 +112,9 @@ impl Setter<EfhBulldozerSpiMode> for EfhBulldozerSpiMode {
 }
 
 #[repr(u8)]
-#[derive(Debug, PartialEq, FromPrimitive, ToPrimitive, Clone, Copy, serde::Deserialize, serde::Serialize)]
-#[cfg_attr(feature = "std", derive(schemars::JsonSchema))]
+#[derive(Debug, PartialEq, FromPrimitive, ToPrimitive, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub enum SpiNaplesMicronMode {
 	DummyCycle = 0x0a,
@@ -163,8 +166,9 @@ impl Setter<EfhRomeSpiMode> for EfhRomeSpiMode {
 }
 
 #[repr(u8)]
-#[derive(Debug, PartialEq, FromPrimitive, ToPrimitive, Clone, Copy, serde::Deserialize, serde::Serialize)]
-#[cfg_attr(feature = "std", derive(schemars::JsonSchema))]
+#[derive(Debug, PartialEq, FromPrimitive, ToPrimitive, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub enum SpiRomeMicronMode {
 	SupportMicron = 0x55,
@@ -243,8 +247,9 @@ impl Default for Efh {
 }
 
 #[repr(i8)]
-#[derive(Debug, PartialEq, FromPrimitive, Clone, Copy, EnumString, serde::Deserialize, serde::Serialize, strum_macros::EnumIter)]
-#[cfg_attr(feature = "std", derive(schemars::JsonSchema))]
+#[derive(Debug, PartialEq, FromPrimitive, Clone, Copy, EnumString, strum_macros::EnumIter)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum ProcessorGeneration {
 	Naples = -1,
 	Rome = 0,
@@ -304,8 +309,9 @@ impl Efh {
 	}
 }
 
-#[derive(Debug, PartialEq, Eq, FromPrimitive, Clone, Copy, BitfieldSpecifier, serde::Deserialize, serde::Serialize)]
-#[cfg_attr(feature = "std", derive(schemars::JsonSchema))]
+#[derive(Debug, PartialEq, Eq, FromPrimitive, Clone, Copy, BitfieldSpecifier)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum AddressMode {
 	/// Only supported for images <= 16 MiB.
 	/// Right-justified in 4 GiB address space.
@@ -459,8 +465,8 @@ macro_rules! make_bitfield_serde {(
 	}
 
 	paste::paste! {
-		#[derive(serde::Deserialize, serde::Serialize)]
-		#[cfg_attr(feature = "std", derive(schemars::JsonSchema))]
+                #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+		#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 		//#[serde(remote = "" $StructName)]
 		pub(crate) struct [<Serde $StructName>] {
 			$(
@@ -635,8 +641,9 @@ impl core::fmt::Debug for PspDirectoryHeader {
 }
 
 #[repr(u8)]
-#[derive(Debug, PartialEq, FromPrimitive, Clone, Copy, BitfieldSpecifier, serde::Deserialize, serde::Serialize)]
-#[cfg_attr(feature = "std", derive(schemars::JsonSchema))]
+#[derive(Debug, PartialEq, FromPrimitive, Clone, Copy, BitfieldSpecifier)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[bits = 8]
 #[non_exhaustive]
 pub enum PspDirectoryEntryType {
@@ -727,8 +734,9 @@ impl DummyErrorChecks for PspDirectoryEntryType {
 }
 
 /// For 32 MiB SPI Flash, which half to map to MMIO 0xff00_0000.
-#[derive(Debug, PartialEq, FromPrimitive, Clone, Copy, BitfieldSpecifier, serde::Deserialize, serde::Serialize)]
-#[cfg_attr(feature = "std", derive(schemars::JsonSchema))]
+#[derive(Debug, PartialEq, FromPrimitive, Clone, Copy, BitfieldSpecifier)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[bits = 1]
 pub enum PspSoftFuseChain32MiBSpiDecoding {
 	LowerHalf = 0,
@@ -738,8 +746,9 @@ pub enum PspSoftFuseChain32MiBSpiDecoding {
 impl DummyErrorChecks for PspSoftFuseChain32MiBSpiDecoding {
 }
 
-#[derive(Debug, PartialEq, FromPrimitive, Clone, Copy, BitfieldSpecifier, serde::Deserialize, serde::Serialize)]
-#[cfg_attr(feature = "std", derive(schemars::JsonSchema))]
+#[derive(Debug, PartialEq, FromPrimitive, Clone, Copy, BitfieldSpecifier)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[bits = 1]
 pub enum PspSoftFuseChainPostCodeDecoding {
 	Lpc = 0,
@@ -785,8 +794,9 @@ impl Default for PspSoftFuseChain {
 }
 
 #[repr(u8)]
-#[derive(Debug, PartialEq, FromPrimitive, Clone, Copy, BitfieldSpecifier, serde::Deserialize, serde::Serialize)]
-#[cfg_attr(feature = "std", derive(schemars::JsonSchema))]
+#[derive(Debug, PartialEq, FromPrimitive, Clone, Copy, BitfieldSpecifier)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[bits = 2]
 #[non_exhaustive]
 pub enum PspDirectoryRomId {
@@ -804,8 +814,9 @@ impl Default for PspDirectoryRomId {
 }
 
 #[repr(u8)]
-#[derive(Debug, PartialEq, FromPrimitive, Clone, Copy, BitfieldSpecifier, serde::Deserialize, serde::Serialize)]
-#[cfg_attr(feature = "std", derive(schemars::JsonSchema))]
+#[derive(Debug, PartialEq, FromPrimitive, Clone, Copy, BitfieldSpecifier)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[bits = 2]
 #[non_exhaustive]
 pub enum BhdDirectoryRomId {
@@ -841,14 +852,15 @@ fn zero() -> u8 {
 }
 
 #[doc(hidden)]
-#[derive(serde::Serialize, serde::Deserialize)]
-#[cfg_attr(feature = "std", derive(schemars::JsonSchema))]
+#[cfg(feature = "serde")]
+#[derive(serde::Deserialize, serde::Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct CustomSerdePspDirectoryEntryAttrs {
-	#[serde(rename = "type")]
+	#[cfg_attr(feature = "serde", serde(rename = "type"))]
 	pub type_: PspDirectoryEntryType,
-	#[serde(default = "zero")]
+	#[cfg_attr(feature = "serde", serde(default = "zero"))]
 	pub sub_program: u8,
-	#[serde(default)]
+	#[cfg_attr(feature = "serde", serde(default))]
 	pub rom_id: PspDirectoryRomId,
 }
 
@@ -1042,8 +1054,9 @@ impl core::fmt::Debug for BhdDirectoryHeader {
 }
 
 #[repr(u8)]
-#[derive(Debug, PartialEq, FromPrimitive, Clone, Copy, BitfieldSpecifier, serde::Deserialize, serde::Serialize)]
-#[cfg_attr(feature = "std", derive(schemars::JsonSchema))]
+#[derive(Debug, PartialEq, FromPrimitive, Clone, Copy, BitfieldSpecifier)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[bits = 8]
 #[non_exhaustive]
 pub enum BhdDirectoryEntryType {
@@ -1068,8 +1081,9 @@ pub enum BhdDirectoryEntryType {
 impl DummyErrorChecks for BhdDirectoryEntryType {
 }
 
-#[derive(Copy, Clone, Debug, FromPrimitive, BitfieldSpecifier, serde::Deserialize, serde::Serialize)]
-#[cfg_attr(feature = "std", derive(schemars::JsonSchema))]
+#[derive(Copy, Clone, Debug, FromPrimitive, BitfieldSpecifier)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[bits = 8]
 #[non_exhaustive]
 pub enum BhdDirectoryEntryRegionType {
@@ -1133,8 +1147,9 @@ fn sub_program_default() -> u8 {
 }
 
 #[doc(hidden)]
-#[derive(serde::Serialize, serde::Deserialize)]
-#[cfg_attr(feature = "std", derive(schemars::JsonSchema))]
+#[cfg(feature = "serde")]
+#[derive(serde::Deserialize, serde::Serialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct CustomSerdeBhdDirectoryEntryAttrs {
 	#[serde(rename = "type")]
 	pub type_: BhdDirectoryEntryType,
@@ -1328,8 +1343,9 @@ impl core::fmt::Debug for BhdDirectoryEntry {
 }
 
 #[repr(u32)]
-#[derive(Debug, PartialEq, FromPrimitive, ToPrimitive, Clone, Copy, serde::Deserialize, serde::Serialize)]
-#[cfg_attr(feature = "std", derive(schemars::JsonSchema))]
+#[derive(Debug, PartialEq, FromPrimitive, ToPrimitive, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub enum ComboDirectoryLookupMode {
 	BruteForce = 0,
@@ -1400,8 +1416,9 @@ impl ComboDirectoryHeader {
 }
 
 //#[repr(u8)]
-#[derive(Debug, PartialEq, Eq, Clone, Copy, serde::Deserialize, serde::Serialize, PartialOrd, Ord)]
-#[cfg_attr(feature = "std", derive(schemars::JsonSchema))]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub enum ComboDirectoryEntryFilter {
 	PspId(u32), // = 0,

--- a/src/serializers.rs
+++ b/src/serializers.rs
@@ -3,6 +3,8 @@
 // Note that if too many fields are private, it means that those are not in the proxy struct in the first place. This might cause problems.
 // Also, serialization can fail if the nice simple user-visible type cannot represent what we are doing.
 
+#![cfg(feature = "serde")]
+
 use crate::ondisk::*;
 use crate::struct_accessors::DummyErrorChecks;
 
@@ -31,7 +33,7 @@ macro_rules! make_serde{($StructName:ident, $SerdeStructName:ident, [$($field_na
 				}.serialize(serializer)
 			}
 		}
-		#[cfg(feature = "std")]
+		#[cfg(feature = "schemars")]
 		impl schemars::JsonSchema for $StructName {
 			fn schema_name() -> String {
 				$SerdeStructName::schema_name()

--- a/src/struct_accessors.rs
+++ b/src/struct_accessors.rs
@@ -224,11 +224,12 @@ macro_rules! make_accessors {(
 	// for serde
 	paste::paste!{
 		#[doc(hidden)]
+		#[cfg(feature = "serde")]
 		#[derive(serde::Serialize, serde::Deserialize)]
-		#[cfg_attr(feature = "std", derive(schemars::JsonSchema))]
+		#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 		// Make it possible to just delegate serde entirely to
 		// this struct instead of $StructName
-		#[serde(rename = "" $StructName)]
+		#[cfg_attr(feature = "serde", serde(rename = "" $StructName))]
 		// Doing remoting automatically would make it impossible for the user to use another one.
 		// Since the config format presumably needs to be
 		// backward-compatible, that wouldn't be such a great idea.


### PR DESCRIPTION
Previously, `amd-efs` gated `serde` on its `std` feature.

In order to have feature parity with `amd-apcb`, it would be better to also introduce extra features `serde` and `schemars` like we did there.

That's what this PR does.
