### PR TITLE
efs: Factor out the remaining directory payload accessors to the main…

### DIFF
--- a/src/ondisk.rs
+++ b/src/ondisk.rs
@@ -1326,7 +1326,7 @@ pub enum ComboDirectoryLookupMode {
 }
 
 make_accessors! {
-	#[derive(FromBytes, AsBytes, Unaligned, Clone, Copy)]
+	#[derive(FromBytes, AsBytes, Unaligned, Clone, Copy, Debug)]
 	#[repr(C, packed)]
 	pub struct ComboDirectoryHeader {
 		pub(crate) cookie: [u8; 4], // b"2PSP" or b"2BHD"


### PR DESCRIPTION
… impl.

While we are at it, add a new combo_subdirectory accessor.


(Since we want to eventually use an allocator to allocate space for the payload elsewhere (not inside the Directory), it makes sense to move those to the main impl in preparation)

Fixes <https://github.com/oxidecomputer/amd-efs/issues/23>.