### PR TITLE
Adopt a consistent rustfmt.toml

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,8 +1,4 @@
+edition = "2021"
 max_width = 80
-hard_tabs = true
-tab_spaces = 8
-spaces_around_ranges = true
-binop_separator = "Back"
+use_small_heuristics = "Max"
 newline_style = "Unix"
-#error_on_line_overflow = true
-error_on_unformatted = true

--- a/src/adapters.rs
+++ b/src/adapters.rs
@@ -10,58 +10,55 @@ const MODULUS: u32 = 0x200_0000; // 32 MiB
 /// This is a flash adapter that allows you to simulate what AMD does when it's using the upper half of a 32 MiB flash chip.
 /// Especially, it is the case that if locations are big enough (i.e. bit 24 set), then they refer to the lower half again.
 pub struct Upper16MiBFlashAdapter<'a> {
-	underlying_reader: &'a dyn FlashRead,
-	underlying_writer: &'a dyn FlashWrite,
+    underlying_reader: &'a dyn FlashRead,
+    underlying_writer: &'a dyn FlashWrite,
 }
 
 impl FlashRead for Upper16MiBFlashAdapter<'_> {
-	fn read_exact(&self, offset: u32, buf: &mut [u8]) -> Result<()> {
-		let offset = (offset + UPPER_HALF_OFFSET) % MODULUS;
-		self.underlying_reader.read_exact(offset, buf)
-	}
+    fn read_exact(&self, offset: u32, buf: &mut [u8]) -> Result<()> {
+        let offset = (offset + UPPER_HALF_OFFSET) % MODULUS;
+        self.underlying_reader.read_exact(offset, buf)
+    }
 }
 
 impl FlashAlign for Upper16MiBFlashAdapter<'_> {
-	fn erasable_block_size(&self) -> usize {
-		self.underlying_writer.erasable_block_size()
-	}
+    fn erasable_block_size(&self) -> usize {
+        self.underlying_writer.erasable_block_size()
+    }
 }
 
 impl FlashWrite for Upper16MiBFlashAdapter<'_> {
-	fn erase_block(
-		&self,
-		offset: ErasableLocation,
-	) -> core::result::Result<(), amd_flash::Error> {
-		let offset = self.location(offset)?;
-		let offset = (offset + UPPER_HALF_OFFSET) % MODULUS;
-		self.underlying_writer.erase_block(
-			self.erasable_location(offset)
-				.ok_or(amd_flash::Error::Alignment)?,
-		)
-	}
-	fn erase_and_write_block(
-		&self,
-		offset: ErasableLocation,
-		buf: &[u8],
-	) -> core::result::Result<(), amd_flash::Error> {
-		let offset = self.location(offset)?;
-		let offset = (offset + UPPER_HALF_OFFSET) % MODULUS;
-		self.underlying_writer.erase_and_write_block(
-			self.erasable_location(offset)
-				.ok_or(amd_flash::Error::Alignment)?,
-			buf,
-		)
-	}
+    fn erase_block(
+        &self,
+        offset: ErasableLocation,
+    ) -> core::result::Result<(), amd_flash::Error> {
+        let offset = self.location(offset)?;
+        let offset = (offset + UPPER_HALF_OFFSET) % MODULUS;
+        self.underlying_writer.erase_block(
+            self.erasable_location(offset)
+                .ok_or(amd_flash::Error::Alignment)?,
+        )
+    }
+    fn erase_and_write_block(
+        &self,
+        offset: ErasableLocation,
+        buf: &[u8],
+    ) -> core::result::Result<(), amd_flash::Error> {
+        let offset = self.location(offset)?;
+        let offset = (offset + UPPER_HALF_OFFSET) % MODULUS;
+        self.underlying_writer.erase_and_write_block(
+            self.erasable_location(offset)
+                .ok_or(amd_flash::Error::Alignment)?,
+            buf,
+        )
+    }
 }
 
 impl<'a> Upper16MiBFlashAdapter<'a> {
-	pub fn new(
-		underlying_reader: &'a dyn FlashRead,
-		underlying_writer: &'a dyn FlashWrite,
-	) -> Self {
-		Self {
-			underlying_reader,
-			underlying_writer,
-		}
-	}
+    pub fn new(
+        underlying_reader: &'a dyn FlashRead,
+        underlying_writer: &'a dyn FlashWrite,
+    ) -> Self {
+        Self { underlying_reader, underlying_writer }
+    }
 }

--- a/src/amdfletcher32.rs
+++ b/src/amdfletcher32.rs
@@ -6,68 +6,68 @@ use fletcher::generic_fletcher::FletcherAccumulator;
 pub struct Wu32(u32);
 
 impl Wu32 {
-	pub fn value(&self) -> u32 {
-		self.0
-	}
+    pub fn value(&self) -> u32 {
+        self.0
+    }
 }
 
 impl Add for Wu32 {
-	type Output = Self;
-	fn add(self, other: Self) -> <Self as Add<Self>>::Output {
-		Self(self.0.add(other.0))
-	}
+    type Output = Self;
+    fn add(self, other: Self) -> <Self as Add<Self>>::Output {
+        Self(self.0.add(other.0))
+    }
 }
 
 impl BitAnd for Wu32 {
-	type Output = Self;
-	fn bitand(self, other: Self) -> Self::Output {
-		Self(self.0.bitand(other.0))
-	}
+    type Output = Self;
+    fn bitand(self, other: Self) -> Self::Output {
+        Self(self.0.bitand(other.0))
+    }
 }
 
 impl BitOr for Wu32 {
-	type Output = Self;
-	fn bitor(self, other: Self) -> Self::Output {
-		Self(self.0.bitor(other.0))
-	}
+    type Output = Self;
+    fn bitor(self, other: Self) -> Self::Output {
+        Self(self.0.bitor(other.0))
+    }
 }
 
 impl Shr for Wu32 {
-	type Output = Self;
-	fn shr(self, other: Self) -> Self::Output {
-		Self(self.0.shr(other.0))
-	}
+    type Output = Self;
+    fn shr(self, other: Self) -> Self::Output {
+        Self(self.0.shr(other.0))
+    }
 }
 
 impl Shl for Wu32 {
-	type Output = Self;
-	fn shl(self, other: Self) -> Self::Output {
-		Self(self.0.shl(other.0))
-	}
+    type Output = Self;
+    fn shl(self, other: Self) -> Self::Output {
+        Self(self.0.shl(other.0))
+    }
 }
 
 impl From<u16> for Wu32 {
-	fn from(value: u16) -> Self {
-		Self(value.into())
-	}
+    fn from(value: u16) -> Self {
+        Self(value.into())
+    }
 }
 
 pub type AmdFletcher32 = Fletcher<Wu32, u16>;
 
 impl FletcherAccumulator<u16> for Wu32 {
-	fn default_value() -> Self {
-		Wu32(0x0000ffff)
-	}
+    fn default_value() -> Self {
+        Wu32(0x0000ffff)
+    }
 
-	fn max_chunk_size() -> usize {
-		359
-	}
+    fn max_chunk_size() -> usize {
+        359
+    }
 
-	fn combine(lower: &Self, upper: &Self) -> Self {
-		*lower | (*upper << Wu32(16))
-	}
+    fn combine(lower: &Self, upper: &Self) -> Self {
+        *lower | (*upper << Wu32(16))
+    }
 
-	fn reduce(self) -> Self {
-		(self & Wu32(0xffff)) + (self >> Wu32(16))
-	}
+    fn reduce(self) -> Self {
+        (self & Wu32(0xffff)) + (self >> Wu32(16))
+    }
 }

--- a/src/efs.rs
+++ b/src/efs.rs
@@ -5,16 +5,18 @@ use crate::ondisk::DirectoryEntrySerde;
 pub use crate::ondisk::ProcessorGeneration;
 use crate::ondisk::EFH_POSITION;
 use crate::ondisk::{
-	mmio_decode, mmio_encode, AddressMode, BhdDirectoryEntry,
-	BhdDirectoryEntryType, BhdDirectoryHeader, ComboDirectoryEntry,
-	ComboDirectoryHeader, DirectoryAdditionalInfo, DirectoryEntry,
-	DirectoryHeader, Efh, EfhBulldozerSpiMode, EfhNaplesSpiMode,
-	EfhRomeSpiMode, PspDirectoryEntry, PspDirectoryEntryType,
-	PspDirectoryHeader, ValueOrLocation, WEAK_ADDRESS_MODE,
+    mmio_decode, mmio_encode, AddressMode, BhdDirectoryEntry,
+    BhdDirectoryEntryType, BhdDirectoryHeader, ComboDirectoryEntry,
+    ComboDirectoryHeader, DirectoryAdditionalInfo, DirectoryEntry,
+    DirectoryHeader, Efh, EfhBulldozerSpiMode, EfhNaplesSpiMode,
+    EfhRomeSpiMode, PspDirectoryEntry, PspDirectoryEntryType,
+    PspDirectoryHeader, ValueOrLocation, WEAK_ADDRESS_MODE,
 };
 use crate::types::Error;
 use crate::types::Result;
-use amd_flash::{ErasableLocation, ErasableRange, FlashRead, FlashWrite, Location};
+use amd_flash::{
+    ErasableLocation, ErasableRange, FlashRead, FlashWrite, Location,
+};
 use core::convert::TryInto;
 use core::mem::size_of;
 use zerocopy::AsBytes;
@@ -22,920 +24,877 @@ use zerocopy::FromBytes;
 
 // TODO: split into Directory and DirectoryContents (disjunct) if requested in additional_info.
 pub struct Directory<
-	MainHeader,
-	Item: DirectoryEntry + FromBytes + AsBytes + Default,
-	const MAIN_HEADER_SIZE: usize,
-	const ITEM_SIZE: usize,
+    MainHeader,
+    Item: DirectoryEntry + FromBytes + AsBytes + Default,
+    const MAIN_HEADER_SIZE: usize,
+    const ITEM_SIZE: usize,
 > {
-	directory_address_mode: AddressMode,
-	header: MainHeader,
-	directory_headers_size: u32,
-	// On AMD, this field specifies how much of the memory area under
-	// address 2**32 (towards lower addresses) is used to memory-map
-	// Flash. This is used in order to store pointers to other
-	// areas on Flash (with ValueOrLocation::PhysicalAddress).
-	amd_physical_mode_mmio_size: Option<u32>,
-	entries: [Item; 64],
+    directory_address_mode: AddressMode,
+    header: MainHeader,
+    directory_headers_size: u32,
+    // On AMD, this field specifies how much of the memory area under
+    // address 2**32 (towards lower addresses) is used to memory-map
+    // Flash. This is used in order to store pointers to other
+    // areas on Flash (with ValueOrLocation::PhysicalAddress).
+    amd_physical_mode_mmio_size: Option<u32>,
+    entries: [Item; 64],
 }
 
 impl<
-		MainHeader: Copy + DirectoryHeader + FromBytes + AsBytes + Default,
-		Item: Copy + DirectoryEntrySerde + DirectoryEntry + core::fmt::Debug + FromBytes + AsBytes + Default,
-		const MAIN_HEADER_SIZE: usize,
-		const ITEM_SIZE: usize,
-	>
-	Directory<
-		MainHeader,
-		Item,
-		MAIN_HEADER_SIZE,
-		ITEM_SIZE,
-	>
+        MainHeader: Copy + DirectoryHeader + FromBytes + AsBytes + Default,
+        Item: Copy
+            + DirectoryEntrySerde
+            + DirectoryEntry
+            + core::fmt::Debug
+            + FromBytes
+            + AsBytes
+            + Default,
+        const MAIN_HEADER_SIZE: usize,
+        const ITEM_SIZE: usize,
+    > Directory<MainHeader, Item, MAIN_HEADER_SIZE, ITEM_SIZE>
 {
-	const MAX_DIRECTORY_ENTRIES: usize = 64; // FIXME
+    const MAX_DIRECTORY_ENTRIES: usize = 64; // FIXME
 
-	pub fn header(&self) -> MainHeader {
-		self.header
-	}
-	pub fn directory_address_mode(&self) -> AddressMode {
-		self.directory_address_mode
-	}
-	pub fn minimal_directory_size(total_entries: u32) -> Result<u32> {
-		size_of::<MainHeader>()
-			.checked_add(
-				size_of::<Item>()
-					.checked_mul(total_entries as usize)
-					.ok_or(Error::DirectoryRangeCheck)?,
-			)
-			.ok_or(Error::DirectoryRangeCheck)?
-			.try_into()
-			.map_err(|_| Error::DirectoryRangeCheck)
-	}
+    pub fn header(&self) -> MainHeader {
+        self.header
+    }
+    pub fn directory_address_mode(&self) -> AddressMode {
+        self.directory_address_mode
+    }
+    pub fn minimal_directory_size(total_entries: u32) -> Result<u32> {
+        size_of::<MainHeader>()
+            .checked_add(
+                size_of::<Item>()
+                    .checked_mul(total_entries as usize)
+                    .ok_or(Error::DirectoryRangeCheck)?,
+            )
+            .ok_or(Error::DirectoryRangeCheck)?
+            .try_into()
+            .map_err(|_| Error::DirectoryRangeCheck)
+    }
 
-	/// Note: Caller has to check whether it is the right cookie (possibly afterwards)!
-	pub fn load<'a, T: FlashRead>(
-		storage: &'a T,
-		location: Location,
-		amd_physical_mode_mmio_size: Option<u32>,
-	) -> Result<Self> {
-		let mut buf: [u8; MAIN_HEADER_SIZE] = [0xff; MAIN_HEADER_SIZE];
-		assert_eq!(MAIN_HEADER_SIZE, size_of::<MainHeader>()); // TODO: move to compile-time
-		storage.read_exact(location, &mut buf)?;
-		match header_from_collection::<MainHeader>(&buf[..]) {
-			Some(header) => {
-				let cookie = header.cookie();
-				if cookie == *b"$PSP" ||
-					cookie == *b"$PL2" || cookie == *b"$BHD" ||
-					cookie == *b"$BL2" || cookie == *b"2PSP"
-				{
-					let directory_address_mode = header
-						.additional_info()
-						.address_mode();
-					match directory_address_mode {
-						AddressMode::PhysicalAddress | AddressMode::EfsRelativeOffset | AddressMode::DirectoryRelativeOffset => {
-						}
-						_ => {
-							return Err(Error::DirectoryTypeMismatch)
-						}
-					}
-					let mut entries = [Item::default(); 64];
-					for i in 0..(header.total_entries() as usize) {
-						if i < 64 {
-							let mut buf: [u8; ITEM_SIZE] = [0xff; ITEM_SIZE];
-							assert_eq!(ITEM_SIZE, size_of::<Item>()); // TODO: move to compile-time
-							storage.read_exact(location + (i as u32) * (ITEM_SIZE as u32), &mut buf)?;
-							match header_from_collection::<Item>(&buf[..]) {
-								Some(entry) => {
-									entries[i] = *entry;
-								}
-								None => {
-									return Err(Error::Marshal)
-								}
-							}
-						} else {
-							return Err(Error::DirectoryRangeCheck)
-						}
-					}
-					Ok(Self {
-						directory_address_mode,
-						header: *header,
-						directory_headers_size:
-							Self::minimal_directory_size(
-								header.total_entries(),
-							)?,
-						amd_physical_mode_mmio_size,
-						entries,
-					})
-				} else {
-					Err(Error::Marshal)
-				}
-			}
-			None => Err(Error::Marshal),
-		}
-	}
-	fn create(
-		directory_address_mode: AddressMode,
-		cookie: [u8; 4],
-		amd_physical_mode_mmio_size: Option<u32>,
-		payloads_beginning: Option<ErasableLocation>,
-		entries: &[Item],
-	) -> Result<Self> {
-		// FIXME: handle directory_address_mode
-		let mut header = MainHeader::default();
-		header.set_cookie(cookie);
-		let payloads_beginning = match payloads_beginning {
-			Some(x) => Location::from(x),
-			None => {
-				todo!()
-			}
-		};
-		let mut result = Self {
-			directory_address_mode,
-			header,
-			directory_headers_size:
-				Self::minimal_directory_size(
-					Self::MAX_DIRECTORY_ENTRIES as u32
-				)?,
-			amd_physical_mode_mmio_size,
-			entries: [Item::default(); 64], // FIXME
-		};
-		for entry in entries {
-			result.add_entry_direct(entry)?;
-		}
-		Ok(result)
-	}
-	/// Updates the main header checksum.  Also updates total_entries (in the same header) to TOTAL_ENTRIES.
-	/// Precondition: Since the checksum is over the entire directory, that means that all the directory entries needs to be correct already.
-	fn update_main_header(&mut self, total_entries: u32) -> Result<()> {
-		let mut checksummer = AmdFletcher32::new();
-		//let mut skip: usize = 12; // Skip fields "signature", "checksum" and "total_entries"
-		checksummer.update(&[
-			(total_entries & 0xffff) as u16,
-			(total_entries >> 16) as u16,
-		]);
-		let additional_info = u32::from(self.header.additional_info());
-		checksummer.update(&[
-			(additional_info & 0xffff) as u16,
-			(additional_info >> 16) as u16,
-		]);
-		assert!(ITEM_SIZE % 2 == 0);
-		for i in 0..(self.header.total_entries() as usize) {
-			let entry = &self.entries[i];
-			let bytes = entry.as_bytes();
-			let block = bytes.chunks(2).map(
-				|bytes| {
-					u16::from_le_bytes(
-						bytes.try_into().unwrap(),
-					)
-				}
-			);
-			// TODO: Optimize performance
-			block.clone().for_each(|item: u16| {
-				checksummer.update(&[item])
-			});
-		}
-
-		let checksum = checksummer.value().value();
-		self.header.set_checksum(checksum);
-		Ok(())
-	}
-	#[cfg(feature = "std")]
-	pub fn save<T: FlashRead + FlashWrite>(&mut self, destination: &T, range: ErasableRange, payloads_beginning: ErasableLocation) -> Result<ErasableRange> {
-		let total_entries = self.header.total_entries();
-		//let additional_info = self.header.additional_info();
-		let additional_info = DirectoryAdditionalInfo::new()
-			.with_max_size_checked(
-				DirectoryAdditionalInfo::try_into_unit(
-					range.capacity()
-					.try_into()
-					.map_err(|_| Error::DirectoryRangeCheck)?,
-				)
-				.ok_or(Error::DirectoryRangeCheck)?,
-			)
-			.map_err(|_| Error::DirectoryRangeCheck)?
-			.with_spi_block_size_checked(
-				DirectoryAdditionalInfo::try_into_unit(
-					destination.erasable_block_size() as usize,
-				)
-				.ok_or(Error::DirectoryRangeCheck)?
-				// .try_into()
-				// .map_err(|_| Error::DirectoryRangeCheck)?,
-			)
-			.map_err(|_| Error::DirectoryRangeCheck)?
-			.with_base_address(
-				DirectoryAdditionalInfo::try_into_unit(
-					Location::from(payloads_beginning)
-					.try_into()
-					.map_err(|_| Error::DirectoryRangeCheck)?,
-				)
-				.ok_or(Error::DirectoryRangeCheck)?
-			)
-			.with_address_mode(AddressMode::EfsRelativeOffset);
-		self.header.set_additional_info(additional_info);
-		self.header.set_additional_info(additional_info);
-		self.update_main_header(total_entries)?;
-                let size = Self::minimal_directory_size(total_entries)?;
-                let (range, rest) = range.split_at_least(size as usize);
-                let mut result = Vec::<u8>::new();
-                result.extend_from_slice(self.header.as_bytes());
-                for entry in &self.entries[..total_entries as usize] {
-                	result.extend_from_slice(entry.as_bytes());
+    /// Note: Caller has to check whether it is the right cookie (possibly afterwards)!
+    pub fn load<'a, T: FlashRead>(
+        storage: &'a T,
+        location: Location,
+        amd_physical_mode_mmio_size: Option<u32>,
+    ) -> Result<Self> {
+        let mut buf: [u8; MAIN_HEADER_SIZE] = [0xff; MAIN_HEADER_SIZE];
+        assert_eq!(MAIN_HEADER_SIZE, size_of::<MainHeader>()); // TODO: move to compile-time
+        storage.read_exact(location, &mut buf)?;
+        match header_from_collection::<MainHeader>(&buf[..]) {
+            Some(header) => {
+                let cookie = header.cookie();
+                if cookie == *b"$PSP"
+                    || cookie == *b"$PL2"
+                    || cookie == *b"$BHD"
+                    || cookie == *b"$BL2"
+                    || cookie == *b"2PSP"
+                {
+                    let directory_address_mode =
+                        header.additional_info().address_mode();
+                    match directory_address_mode {
+                        AddressMode::PhysicalAddress
+                        | AddressMode::EfsRelativeOffset
+                        | AddressMode::DirectoryRelativeOffset => {}
+                        _ => return Err(Error::DirectoryTypeMismatch),
+                    }
+                    let mut entries = [Item::default(); 64];
+                    for i in 0..(header.total_entries() as usize) {
+                        if i < 64 {
+                            let mut buf: [u8; ITEM_SIZE] = [0xff; ITEM_SIZE];
+                            assert_eq!(ITEM_SIZE, size_of::<Item>()); // TODO: move to compile-time
+                            storage.read_exact(
+                                location + (i as u32) * (ITEM_SIZE as u32),
+                                &mut buf,
+                            )?;
+                            match header_from_collection::<Item>(&buf[..]) {
+                                Some(entry) => {
+                                    entries[i] = *entry;
+                                }
+                                None => return Err(Error::Marshal),
+                            }
+                        } else {
+                            return Err(Error::DirectoryRangeCheck);
+                        }
+                    }
+                    Ok(Self {
+                        directory_address_mode,
+                        header: *header,
+                        directory_headers_size: Self::minimal_directory_size(
+                            header.total_entries(),
+                        )?,
+                        amd_physical_mode_mmio_size,
+                        entries,
+                    })
+                } else {
+                    Err(Error::Marshal)
                 }
-                destination.erase_and_write_blocks(range.beginning, &result)?;
-		Ok(rest)
-	}
-	pub fn entries(&self) -> impl Iterator<Item=Item> + '_ {
-		let mut index = 0usize;
-		core::iter::from_fn(move || {
-			if index < self.header.total_entries() as usize {
-				let result = self.entries[index];
-				index = index + 1;
-				Some(result)
-			} else {
-				None
-			}
-		})
-	}
+            }
+            None => Err(Error::Marshal),
+        }
+    }
+    fn create(
+        directory_address_mode: AddressMode,
+        cookie: [u8; 4],
+        amd_physical_mode_mmio_size: Option<u32>,
+        payloads_beginning: Option<ErasableLocation>,
+        entries: &[Item],
+    ) -> Result<Self> {
+        // FIXME: handle directory_address_mode
+        let mut header = MainHeader::default();
+        header.set_cookie(cookie);
+        let payloads_beginning = match payloads_beginning {
+            Some(x) => Location::from(x),
+            None => {
+                todo!()
+            }
+        };
+        let mut result = Self {
+            directory_address_mode,
+            header,
+            directory_headers_size: Self::minimal_directory_size(
+                Self::MAX_DIRECTORY_ENTRIES as u32,
+            )?,
+            amd_physical_mode_mmio_size,
+            entries: [Item::default(); 64], // FIXME
+        };
+        for entry in entries {
+            result.add_entry_direct(entry)?;
+        }
+        Ok(result)
+    }
+    /// Updates the main header checksum.  Also updates total_entries (in the same header) to TOTAL_ENTRIES.
+    /// Precondition: Since the checksum is over the entire directory, that means that all the directory entries needs to be correct already.
+    fn update_main_header(&mut self, total_entries: u32) -> Result<()> {
+        let mut checksummer = AmdFletcher32::new();
+        //let mut skip: usize = 12; // Skip fields "signature", "checksum" and "total_entries"
+        checksummer.update(&[
+            (total_entries & 0xffff) as u16,
+            (total_entries >> 16) as u16,
+        ]);
+        let additional_info = u32::from(self.header.additional_info());
+        checksummer.update(&[
+            (additional_info & 0xffff) as u16,
+            (additional_info >> 16) as u16,
+        ]);
+        assert!(ITEM_SIZE % 2 == 0);
+        for i in 0..(self.header.total_entries() as usize) {
+            let entry = &self.entries[i];
+            let bytes = entry.as_bytes();
+            let block = bytes
+                .chunks(2)
+                .map(|bytes| u16::from_le_bytes(bytes.try_into().unwrap()));
+            // TODO: Optimize performance
+            block.clone().for_each(|item: u16| checksummer.update(&[item]));
+        }
 
-	pub(crate) fn add_entry_direct(
-		&mut self,
-		entry: &Item,
-	) -> Result<()> {
-		let total_entries = self
-			.header
-			.total_entries()
-			.checked_add(1)
-			.ok_or(Error::DirectoryRangeCheck)?;
-		self.entries[total_entries as usize - 1] = *entry;
-		self.header.set_total_entries(total_entries);
-		Ok(())
-	}
+        let checksum = checksummer.value().value();
+        self.header.set_checksum(checksum);
+        Ok(())
+    }
+    #[cfg(feature = "std")]
+    pub fn save<T: FlashRead + FlashWrite>(
+        &mut self,
+        destination: &T,
+        range: ErasableRange,
+        payloads_beginning: ErasableLocation,
+    ) -> Result<ErasableRange> {
+        let total_entries = self.header.total_entries();
+        //let additional_info = self.header.additional_info();
+        let additional_info = DirectoryAdditionalInfo::new()
+            .with_max_size_checked(
+                DirectoryAdditionalInfo::try_into_unit(
+                    range
+                        .capacity()
+                        .try_into()
+                        .map_err(|_| Error::DirectoryRangeCheck)?,
+                )
+                .ok_or(Error::DirectoryRangeCheck)?,
+            )
+            .map_err(|_| Error::DirectoryRangeCheck)?
+            .with_spi_block_size_checked(
+                DirectoryAdditionalInfo::try_into_unit(
+                    destination.erasable_block_size() as usize,
+                )
+                .ok_or(Error::DirectoryRangeCheck)?, // .try_into()
+                                                     // .map_err(|_| Error::DirectoryRangeCheck)?,
+            )
+            .map_err(|_| Error::DirectoryRangeCheck)?
+            .with_base_address(
+                DirectoryAdditionalInfo::try_into_unit(
+                    Location::from(payloads_beginning)
+                        .try_into()
+                        .map_err(|_| Error::DirectoryRangeCheck)?,
+                )
+                .ok_or(Error::DirectoryRangeCheck)?,
+            )
+            .with_address_mode(AddressMode::EfsRelativeOffset);
+        self.header.set_additional_info(additional_info);
+        self.header.set_additional_info(additional_info);
+        self.update_main_header(total_entries)?;
+        let size = Self::minimal_directory_size(total_entries)?;
+        let (range, rest) = range.split_at_least(size as usize);
+        let mut result = Vec::<u8>::new();
+        result.extend_from_slice(self.header.as_bytes());
+        for entry in &self.entries[..total_entries as usize] {
+            result.extend_from_slice(entry.as_bytes());
+        }
+        destination.erase_and_write_blocks(range.beginning, &result)?;
+        Ok(rest)
+    }
+    pub fn entries(&self) -> impl Iterator<Item = Item> + '_ {
+        let mut index = 0usize;
+        core::iter::from_fn(move || {
+            if index < self.header.total_entries() as usize {
+                let result = self.entries[index];
+                index = index + 1;
+                Some(result)
+            } else {
+                None
+            }
+        })
+    }
+
+    pub(crate) fn add_entry_direct(&mut self, entry: &Item) -> Result<()> {
+        let total_entries = self
+            .header
+            .total_entries()
+            .checked_add(1)
+            .ok_or(Error::DirectoryRangeCheck)?;
+        self.entries[total_entries as usize - 1] = *entry;
+        self.header.set_total_entries(total_entries);
+        Ok(())
+    }
 }
 
 pub type PspDirectory = Directory<
-	PspDirectoryHeader,
-	PspDirectoryEntry,
-	{ size_of::<PspDirectoryHeader>() },
-	{ size_of::<PspDirectoryEntry>() },
+    PspDirectoryHeader,
+    PspDirectoryEntry,
+    { size_of::<PspDirectoryHeader>() },
+    { size_of::<PspDirectoryEntry>() },
 >;
 pub type BhdDirectory = Directory<
-	BhdDirectoryHeader,
-	BhdDirectoryEntry,
-	{ size_of::<BhdDirectoryHeader>() },
-	{ size_of::<BhdDirectoryEntry>() },
+    BhdDirectoryHeader,
+    BhdDirectoryEntry,
+    { size_of::<BhdDirectoryHeader>() },
+    { size_of::<BhdDirectoryEntry>() },
 >;
 pub type ComboDirectory = Directory<
-	ComboDirectoryHeader,
-	ComboDirectoryEntry,
-	{ size_of::<ComboDirectoryHeader>() },
-	{ size_of::<ComboDirectoryEntry>() },
+    ComboDirectoryHeader,
+    ComboDirectoryEntry,
+    { size_of::<ComboDirectoryHeader>() },
+    { size_of::<ComboDirectoryEntry>() },
 >;
 
-impl Directory<
-		PspDirectoryHeader,
-		PspDirectoryEntry,
-		{ size_of::<PspDirectoryHeader>() },
-		{ size_of::<PspDirectoryEntry>() },
-	>
+impl
+    Directory<
+        PspDirectoryHeader,
+        PspDirectoryEntry,
+        { size_of::<PspDirectoryHeader>() },
+        { size_of::<PspDirectoryEntry>() },
+    >
 {
-	// TODO: Type-check value
-	pub fn add_value_entry(
-		&mut self,
-		entry: &mut PspDirectoryEntry,
-	) -> Result<()> {
-		if let ValueOrLocation::Value(_) = entry.source(WEAK_ADDRESS_MODE)? {
-			self.add_entry_direct(entry)?;
-			Ok(())
-		} else {
-			Err(Error::EntryTypeMismatch)
-		}
-	}
+    // TODO: Type-check value
+    pub fn add_value_entry(
+        &mut self,
+        entry: &mut PspDirectoryEntry,
+    ) -> Result<()> {
+        if let ValueOrLocation::Value(_) = entry.source(WEAK_ADDRESS_MODE)? {
+            self.add_entry_direct(entry)?;
+            Ok(())
+        } else {
+            Err(Error::EntryTypeMismatch)
+        }
+    }
 }
 
-pub struct EfhBhdsIterator<
-	'a,
-	T: FlashRead + FlashWrite,
-> {
-	storage: &'a T,
-	physical_address_mode: bool,
-	positions: [u32; 4], // 0xffff_ffff: invalid
-	index_into_positions: usize,
-	amd_physical_mode_mmio_size: Option<u32>,
+pub struct EfhBhdsIterator<'a, T: FlashRead + FlashWrite> {
+    storage: &'a T,
+    physical_address_mode: bool,
+    positions: [u32; 4], // 0xffff_ffff: invalid
+    index_into_positions: usize,
+    amd_physical_mode_mmio_size: Option<u32>,
 }
 
-impl<
-		'a,
-		T: FlashRead
-			+ FlashWrite,
-	> Iterator for EfhBhdsIterator<'a, T>
-{
-	type Item = BhdDirectory;
-	fn next(&mut self) -> Option<<Self as Iterator>::Item> {
-		while self.index_into_positions < self.positions.len() {
-			let position =
-				self.positions[self.index_into_positions];
-			self.index_into_positions += 1;
-			if position != 0xffff_ffff && position != 0
-			/* sigh.  Some images have 0 as "invalid" mark */
-			{
-				return BhdDirectory::load(
-					self.storage,
-					position,
-					self.amd_physical_mode_mmio_size,
-				).ok() // FIXME: error check
-			}
-		}
-		None
-	}
+impl<'a, T: FlashRead + FlashWrite> Iterator for EfhBhdsIterator<'a, T> {
+    type Item = BhdDirectory;
+    fn next(&mut self) -> Option<<Self as Iterator>::Item> {
+        while self.index_into_positions < self.positions.len() {
+            let position = self.positions[self.index_into_positions];
+            self.index_into_positions += 1;
+            if position != 0xffff_ffff && position != 0
+            /* sigh.  Some images have 0 as "invalid" mark */
+            {
+                return BhdDirectory::load(
+                    self.storage,
+                    position,
+                    self.amd_physical_mode_mmio_size,
+                )
+                .ok(); // FIXME: error check
+            }
+        }
+        None
+    }
 }
 
 pub const fn preferred_efh_location(
-	processor_generation: ProcessorGeneration,
+    processor_generation: ProcessorGeneration,
 ) -> Location {
-	match processor_generation {
-		ProcessorGeneration::Naples => 0x2_0000,
-		ProcessorGeneration::Rome | ProcessorGeneration::Milan => {
-			0xFA_0000
-		}
-	}
+    match processor_generation {
+        ProcessorGeneration::Naples => 0x2_0000,
+        ProcessorGeneration::Rome | ProcessorGeneration::Milan => 0xFA_0000,
+    }
 }
 
-pub struct Efs<
-	'a,
-	T: FlashRead + FlashWrite,
-> {
-	storage: &'a T,
-	efh_beginning: ErasableLocation,
-	pub efh: Efh,
-	amd_physical_mode_mmio_size: Option<u32>,
+pub struct Efs<'a, T: FlashRead + FlashWrite> {
+    storage: &'a T,
+    efh_beginning: ErasableLocation,
+    pub efh: Efh,
+    amd_physical_mode_mmio_size: Option<u32>,
 }
 
-impl<
-	'a,
-	T: FlashRead + FlashWrite,
-> Efs<'a, T>
-{
-	// FIXME maybe not public
-	pub fn erasable_location(&self, location: Location) -> Option<ErasableLocation> {
-		self.storage.erasable_location(location)
-	}
-	pub fn erasable_location_mut(&mut self, location: Location) -> Option<ErasableLocation> {
-		self.storage.erasable_location(location)
-	}
-	// TODO: If we wanted to, we could also try the whole thing on the top 16 MiB again
-	// (I think it would be better to have the user just construct two
-	// different Efs instances in that case)
-	const EFH_SIZE: u32 = 0x200;
-	pub(crate) fn efh_beginning(
-		storage: &T,
-		processor_generation: Option<ProcessorGeneration>,
-	) -> Result<ErasableLocation> {
-		for position in EFH_POSITION.iter() {
-			let mut xbuf: [u8; size_of::<Efh>()] =
-				[0; size_of::<Efh>()];
-			storage.read_exact(*position, &mut xbuf)?;
-			if let Some(item) =
-				header_from_collection::<Efh>(&xbuf[..])
-			{
-				// Note: only one Efh with second_gen_efs() allowed in entire Flash!
-				if item.signature().ok().unwrap_or(0) ==
-					0x55AA55AA && item.second_gen_efs() &&
-					match processor_generation {
-						Some(x) => item
-							.compatible_with_processor_generation(
-								x,
-							),
-						None => true,
-					} {
-					return Ok(storage.erasable_location(*position).ok_or(Error::Misaligned)?);
-				}
-			}
-		}
-		// Old firmware header is better than no firmware header; TODO: Warn.
-		for position in EFH_POSITION.iter() {
-			let mut xbuf: [u8; size_of::<Efh>()] =
-				[0; size_of::<Efh>()];
-			storage.read_exact(*position, &mut xbuf)?;
-			if let Some(item) =
-				header_from_collection::<Efh>(&xbuf[..])
-			{
-				if item.signature().ok().unwrap_or(0) ==
-					0x55AA55AA && !item.second_gen_efs() &&
-					match processor_generation {
-						//Some(x) => item.compatible_with_processor_generation(x),
-						None => true,
-						Some(ProcessorGeneration::Naples) => true,
-						_ => false,
-					} {
-					return Ok(storage.erasable_location(*position).ok_or(Error::Misaligned)?);
-				}
-			}
-		}
-		Err(Error::EfsHeaderNotFound)
-	}
+impl<'a, T: FlashRead + FlashWrite> Efs<'a, T> {
+    // FIXME maybe not public
+    pub fn erasable_location(
+        &self,
+        location: Location,
+    ) -> Option<ErasableLocation> {
+        self.storage.erasable_location(location)
+    }
+    pub fn erasable_location_mut(
+        &mut self,
+        location: Location,
+    ) -> Option<ErasableLocation> {
+        self.storage.erasable_location(location)
+    }
+    // TODO: If we wanted to, we could also try the whole thing on the top 16 MiB again
+    // (I think it would be better to have the user just construct two
+    // different Efs instances in that case)
+    const EFH_SIZE: u32 = 0x200;
+    pub(crate) fn efh_beginning(
+        storage: &T,
+        processor_generation: Option<ProcessorGeneration>,
+    ) -> Result<ErasableLocation> {
+        for position in EFH_POSITION.iter() {
+            let mut xbuf: [u8; size_of::<Efh>()] = [0; size_of::<Efh>()];
+            storage.read_exact(*position, &mut xbuf)?;
+            if let Some(item) = header_from_collection::<Efh>(&xbuf[..]) {
+                // Note: only one Efh with second_gen_efs() allowed in entire Flash!
+                if item.signature().ok().unwrap_or(0) == 0x55AA55AA
+                    && item.second_gen_efs()
+                    && match processor_generation {
+                        Some(x) => item.compatible_with_processor_generation(x),
+                        None => true,
+                    }
+                {
+                    return Ok(storage
+                        .erasable_location(*position)
+                        .ok_or(Error::Misaligned)?);
+                }
+            }
+        }
+        // Old firmware header is better than no firmware header; TODO: Warn.
+        for position in EFH_POSITION.iter() {
+            let mut xbuf: [u8; size_of::<Efh>()] = [0; size_of::<Efh>()];
+            storage.read_exact(*position, &mut xbuf)?;
+            if let Some(item) = header_from_collection::<Efh>(&xbuf[..]) {
+                if item.signature().ok().unwrap_or(0) == 0x55AA55AA
+                    && !item.second_gen_efs()
+                    && match processor_generation {
+                        //Some(x) => item.compatible_with_processor_generation(x),
+                        None => true,
+                        Some(ProcessorGeneration::Naples) => true,
+                        _ => false,
+                    }
+                {
+                    return Ok(storage
+                        .erasable_location(*position)
+                        .ok_or(Error::Misaligned)?);
+                }
+            }
+        }
+        Err(Error::EfsHeaderNotFound)
+    }
 
-	pub fn physical_address_mode(&self) -> bool {
-		self.efh.physical_address_mode()
-	}
+    pub fn physical_address_mode(&self) -> bool {
+        self.efh.physical_address_mode()
+    }
 
-	/// This loads the Embedded Firmware Structure (EFS) from STORAGE.
-	/// Should the EFS be old enough to still use physical mmio addresses
-	/// for pointers on the Flash, AMD_PHYSICAL_MODE_MMIO_SIZE is required.
-	/// Otherwise, AMD_PHYSICAL_MODE_MMIO_SIZE is allowed to be None.
-	pub fn load(
-		storage: &'a T,
-		processor_generation: Option<ProcessorGeneration>,
-		amd_physical_mode_mmio_size: Option<u32>,
-	) -> Result<Self> {
-		let efh_beginning =
-			Self::efh_beginning(&storage, processor_generation)?;
-		let mut xbuf: [u8; size_of::<Efh>()] =
-			[0; size_of::<Efh>()];
-		storage.read_exact(efh_beginning.into(), &mut xbuf)?;
-		let efh = header_from_collection::<Efh>(&xbuf[..])
-			.ok_or(Error::EfsHeaderNotFound)?;
-		if efh.signature().ok().unwrap_or(0) != 0x55aa_55aa {
-			return Err(Error::EfsHeaderNotFound);
-		}
+    /// This loads the Embedded Firmware Structure (EFS) from STORAGE.
+    /// Should the EFS be old enough to still use physical mmio addresses
+    /// for pointers on the Flash, AMD_PHYSICAL_MODE_MMIO_SIZE is required.
+    /// Otherwise, AMD_PHYSICAL_MODE_MMIO_SIZE is allowed to be None.
+    pub fn load(
+        storage: &'a T,
+        processor_generation: Option<ProcessorGeneration>,
+        amd_physical_mode_mmio_size: Option<u32>,
+    ) -> Result<Self> {
+        let efh_beginning =
+            Self::efh_beginning(&storage, processor_generation)?;
+        let mut xbuf: [u8; size_of::<Efh>()] = [0; size_of::<Efh>()];
+        storage.read_exact(efh_beginning.into(), &mut xbuf)?;
+        let efh = header_from_collection::<Efh>(&xbuf[..])
+            .ok_or(Error::EfsHeaderNotFound)?;
+        if efh.signature().ok().unwrap_or(0) != 0x55aa_55aa {
+            return Err(Error::EfsHeaderNotFound);
+        }
 
-		Ok(Self {
-			storage,
-			efh_beginning,
-			efh: *efh,
-			amd_physical_mode_mmio_size,
-		})
-	}
-	pub fn create(
-		storage: &'a T,
-		processor_generation: ProcessorGeneration,
-		efh_beginning: Location,
-		amd_physical_mode_mmio_size: Option<u32>,
-	) -> Result<Self> {
-		if !EFH_POSITION.contains(&efh_beginning) ||
-			preferred_efh_location(processor_generation) !=
-				efh_beginning
-		{
-			return Err(Error::EfsRangeCheck);
-		}
+        Ok(Self {
+            storage,
+            efh_beginning,
+            efh: *efh,
+            amd_physical_mode_mmio_size,
+        })
+    }
+    pub fn create(
+        storage: &'a T,
+        processor_generation: ProcessorGeneration,
+        efh_beginning: Location,
+        amd_physical_mode_mmio_size: Option<u32>,
+    ) -> Result<Self> {
+        if !EFH_POSITION.contains(&efh_beginning)
+            || preferred_efh_location(processor_generation) != efh_beginning
+        {
+            return Err(Error::EfsRangeCheck);
+        }
 
-		let mut buf: [u8; size_of::<Efh>()] =
-			[0xFF; size_of::<Efh>()]; // FIXME should be: EFH_SIZE == size_of::<Efh>()
-		match header_from_collection_mut(&mut buf[..]) {
-			Some(item) => {
-				let mut efh: Efh = Efh::default();
-				efh.efs_generations.set(
-					Efh::efs_generations_for_processor_generation(
-						processor_generation,
-					),
-				);
-				*item = efh;
-			}
-			None => {
-				return Err(Error::Marshal);
-			}
-		}
+        let mut buf: [u8; size_of::<Efh>()] = [0xFF; size_of::<Efh>()]; // FIXME should be: EFH_SIZE == size_of::<Efh>()
+        match header_from_collection_mut(&mut buf[..]) {
+            Some(item) => {
+                let mut efh: Efh = Efh::default();
+                efh.efs_generations.set(
+                    Efh::efs_generations_for_processor_generation(
+                        processor_generation,
+                    ),
+                );
+                *item = efh;
+            }
+            None => {
+                return Err(Error::Marshal);
+            }
+        }
 
-		storage.erase_and_write_blocks(
-			storage.erasable_location(efh_beginning).ok_or(Error::Misaligned)?,
-			&buf,
-		)?;
-		Self::load(
-			storage,
-			Some(processor_generation),
-			amd_physical_mode_mmio_size,
-		)
-	}
+        storage.erase_and_write_blocks(
+            storage
+                .erasable_location(efh_beginning)
+                .ok_or(Error::Misaligned)?,
+            &buf,
+        )?;
+        Self::load(
+            storage,
+            Some(processor_generation),
+            amd_physical_mode_mmio_size,
+        )
+    }
 
-	/// Note: Either psp_directory or psp_combo_directory will succeed--but not both.
-	pub fn psp_directory(
-		&self,
-	) -> Result<PspDirectory> {
-		let psp_directory_table_location =
-			self.efh.psp_directory_table_location_zen()
-				.ok()
-				.unwrap_or(0xffff_ffff);
-		if psp_directory_table_location == 0xffff_ffff
-		|| psp_directory_table_location == 0 {
-			Err(Error::PspDirectoryHeaderNotFound)
-		} else {
-			match PspDirectory::load(
-				self.storage,
-				psp_directory_table_location,
-				self.amd_physical_mode_mmio_size,
-			) {
-				Ok(directory) => {
-					if directory.header.cookie == *b"$PSP" {
-						// level 1 PSP header should have "$PSP" cookie
-						return Ok(directory);
-					}
-				}
-				Err(Error::Marshal) => {}
-				Err(e) => {
-					return Err(e);
-				}
-			};
+    /// Note: Either psp_directory or psp_combo_directory will succeed--but not both.
+    pub fn psp_directory(&self) -> Result<PspDirectory> {
+        let psp_directory_table_location = self
+            .efh
+            .psp_directory_table_location_zen()
+            .ok()
+            .unwrap_or(0xffff_ffff);
+        if psp_directory_table_location == 0xffff_ffff
+            || psp_directory_table_location == 0
+        {
+            Err(Error::PspDirectoryHeaderNotFound)
+        } else {
+            match PspDirectory::load(
+                self.storage,
+                psp_directory_table_location,
+                self.amd_physical_mode_mmio_size,
+            ) {
+                Ok(directory) => {
+                    if directory.header.cookie == *b"$PSP" {
+                        // level 1 PSP header should have "$PSP" cookie
+                        return Ok(directory);
+                    }
+                }
+                Err(Error::Marshal) => {}
+                Err(e) => {
+                    return Err(e);
+                }
+            };
 
-			// That's the same fallback AMD does on Naples:
+            // That's the same fallback AMD does on Naples:
 
-			let psp_directory_table_location = {
-				let addr = self
-					.efh
-					.psp_directory_table_location_naples()
-					.ok()
-					.unwrap_or(0xffff_ffff);
-				if addr == 0xffff_ffff {
-					addr
-				} else {
-					addr & 0x00ff_ffff
-				}
-			};
-			if psp_directory_table_location == 0xffff_ffff ||
-				psp_directory_table_location == 0
-			{
-				Err(Error::PspDirectoryHeaderNotFound)
-			} else {
-				let directory = PspDirectory::load(
-					self.storage,
-					psp_directory_table_location,
-					self.amd_physical_mode_mmio_size,
-				)?;
-				if directory.header.cookie == *b"$PSP" {
-					// level 1 PSP header should have "$PSP" cookie
-					Ok(directory)
-				} else {
-					Err(Error::Marshal)
-				}
-			}
-		}
-	}
+            let psp_directory_table_location = {
+                let addr = self
+                    .efh
+                    .psp_directory_table_location_naples()
+                    .ok()
+                    .unwrap_or(0xffff_ffff);
+                if addr == 0xffff_ffff {
+                    addr
+                } else {
+                    addr & 0x00ff_ffff
+                }
+            };
+            if psp_directory_table_location == 0xffff_ffff
+                || psp_directory_table_location == 0
+            {
+                Err(Error::PspDirectoryHeaderNotFound)
+            } else {
+                let directory = PspDirectory::load(
+                    self.storage,
+                    psp_directory_table_location,
+                    self.amd_physical_mode_mmio_size,
+                )?;
+                if directory.header.cookie == *b"$PSP" {
+                    // level 1 PSP header should have "$PSP" cookie
+                    Ok(directory)
+                } else {
+                    Err(Error::Marshal)
+                }
+            }
+        }
+    }
 
-	/// Note: Either psp_directory or psp_combo_directory will succeed--but not both.
-	pub fn psp_combo_directory(
-		&self,
-	) -> Result<ComboDirectory> {
-		let psp_directory_table_location =
-			self.efh.psp_directory_table_location_zen()
-				.ok()
-				.unwrap_or(0xffff_ffff);
-		if psp_directory_table_location == 0xffff_ffff {
-			Err(Error::PspDirectoryHeaderNotFound)
-		} else {
-			match ComboDirectory::load(
-				self.storage,
-				psp_directory_table_location,
-				self.amd_physical_mode_mmio_size,
-			) {
-				Ok(directory) => {
-					if directory.header.cookie == *b"2PSP" {
-						return Ok(directory);
-					}
-				}
-				Err(Error::Marshal) => {}
-				Err(e) => {
-					return Err(e);
-				}
-			};
+    /// Note: Either psp_directory or psp_combo_directory will succeed--but not both.
+    pub fn psp_combo_directory(&self) -> Result<ComboDirectory> {
+        let psp_directory_table_location = self
+            .efh
+            .psp_directory_table_location_zen()
+            .ok()
+            .unwrap_or(0xffff_ffff);
+        if psp_directory_table_location == 0xffff_ffff {
+            Err(Error::PspDirectoryHeaderNotFound)
+        } else {
+            match ComboDirectory::load(
+                self.storage,
+                psp_directory_table_location,
+                self.amd_physical_mode_mmio_size,
+            ) {
+                Ok(directory) => {
+                    if directory.header.cookie == *b"2PSP" {
+                        return Ok(directory);
+                    }
+                }
+                Err(Error::Marshal) => {}
+                Err(e) => {
+                    return Err(e);
+                }
+            };
 
-			// That's the same fallback AMD does on Naples:
+            // That's the same fallback AMD does on Naples:
 
-			let psp_directory_table_location = {
-				let addr = self
-					.efh
-					.psp_directory_table_location_naples()
-					.ok()
-					.unwrap_or(0xffff_ffff);
-				if addr == 0xffff_ffff {
-					addr
-				} else {
-					addr & 0x00ff_ffff
-				}
-			};
-			if psp_directory_table_location == 0xffff_ffff ||
-				psp_directory_table_location == 0
-			{
-				Err(Error::PspDirectoryHeaderNotFound)
-			} else {
-				let directory = ComboDirectory::load(
-					self.storage,
-					psp_directory_table_location,
-					self.amd_physical_mode_mmio_size,
-				)?;
-				if directory.header.cookie == *b"2PSP" {
-					Ok(directory)
-				} else {
-					Err(Error::Marshal)
-				}
-			}
-		}
-	}
+            let psp_directory_table_location = {
+                let addr = self
+                    .efh
+                    .psp_directory_table_location_naples()
+                    .ok()
+                    .unwrap_or(0xffff_ffff);
+                if addr == 0xffff_ffff {
+                    addr
+                } else {
+                    addr & 0x00ff_ffff
+                }
+            };
+            if psp_directory_table_location == 0xffff_ffff
+                || psp_directory_table_location == 0
+            {
+                Err(Error::PspDirectoryHeaderNotFound)
+            } else {
+                let directory = ComboDirectory::load(
+                    self.storage,
+                    psp_directory_table_location,
+                    self.amd_physical_mode_mmio_size,
+                )?;
+                if directory.header.cookie == *b"2PSP" {
+                    Ok(directory)
+                } else {
+                    Err(Error::Marshal)
+                }
+            }
+        }
+    }
 
-	/// Returns an iterator over level 1 BHD directories.
-	/// If PROCESSOR_GENERATION is Some, then only return the directories
-	/// matching that generation.
-	pub fn bhd_directories(
-		&self,
-		processor_generation: Option<ProcessorGeneration>,
-	) -> Result<EfhBhdsIterator<T>> {
-		/// Given V which is possibly a MMIO address (from inside a
-		/// directory entry), convert it to a regular offset
-		/// relative to the beginning of the flash.
-		fn de_mmio(
-			v: u32,
-			amd_physical_mode_mmio_size: Option<u32>,
-		) -> u32 {
-			if v == 0xffff_ffff || v == 0 {
-				0xffff_ffff
-			} else if let Some(amd_physical_mode_mmio_size) =
-				amd_physical_mode_mmio_size
-			{
-				match mmio_decode(
-					v,
-					amd_physical_mode_mmio_size,
-				) {
-					Ok(v) => v,
-					Err(Error::DirectoryTypeMismatch) => {
-						// Rome is a grey-area that supports both MMIO addresses and offsets
-						if v < amd_physical_mode_mmio_size {
-							v
-						} else {
-							0xffff_ffff
-						}
-					}
-					Err(_) => 0xffff_ffff,
-				}
-			} else {
-				0xffff_ffff
-			}
-		}
-		let efh = &self.efh;
-		let amd_physical_mode_mmio_size =
-			self.amd_physical_mode_mmio_size;
-		let invalid_position = 0xffff_ffffu32;
-		let positions = match processor_generation {
-			Some(ProcessorGeneration::Milan) => [
-				efh.bhd_directory_table_milan()
-					.ok()
-					.unwrap_or(invalid_position),
-				invalid_position,
-				invalid_position,
-				invalid_position,
-			],
-			Some(ProcessorGeneration::Rome) => [
-				de_mmio(
-					efh.bhd_directory_tables[2].get(),
-					amd_physical_mode_mmio_size,
-				),
-				invalid_position,
-				invalid_position,
-				invalid_position,
-			],
-			Some(ProcessorGeneration::Naples) => [
-				de_mmio(
-					efh.bhd_directory_tables[0].get(),
-					amd_physical_mode_mmio_size,
-				),
-				invalid_position,
-				invalid_position,
-				invalid_position,
-			],
-			None => [
-				// allow all (used for example for overlap checking)
-				efh.bhd_directory_table_milan()
-					.ok()
-					.unwrap_or(invalid_position),
-				de_mmio(
-					efh.bhd_directory_tables[2].get(),
-					amd_physical_mode_mmio_size,
-				),
-				de_mmio(
-					efh.bhd_directory_tables[1].get(),
-					amd_physical_mode_mmio_size,
-				),
-				de_mmio(
-					efh.bhd_directory_tables[0].get(),
-					amd_physical_mode_mmio_size,
-				),
-			],
-		};
-		Ok(EfhBhdsIterator {
-			storage: self.storage,
-			physical_address_mode: self.physical_address_mode(),
-			positions,
-			index_into_positions: 0,
-			amd_physical_mode_mmio_size: self
-				.amd_physical_mode_mmio_size,
-		})
-	}
+    /// Returns an iterator over level 1 BHD directories.
+    /// If PROCESSOR_GENERATION is Some, then only return the directories
+    /// matching that generation.
+    pub fn bhd_directories(
+        &self,
+        processor_generation: Option<ProcessorGeneration>,
+    ) -> Result<EfhBhdsIterator<T>> {
+        /// Given V which is possibly a MMIO address (from inside a
+        /// directory entry), convert it to a regular offset
+        /// relative to the beginning of the flash.
+        fn de_mmio(v: u32, amd_physical_mode_mmio_size: Option<u32>) -> u32 {
+            if v == 0xffff_ffff || v == 0 {
+                0xffff_ffff
+            } else if let Some(amd_physical_mode_mmio_size) =
+                amd_physical_mode_mmio_size
+            {
+                match mmio_decode(v, amd_physical_mode_mmio_size) {
+                    Ok(v) => v,
+                    Err(Error::DirectoryTypeMismatch) => {
+                        // Rome is a grey-area that supports both MMIO addresses and offsets
+                        if v < amd_physical_mode_mmio_size {
+                            v
+                        } else {
+                            0xffff_ffff
+                        }
+                    }
+                    Err(_) => 0xffff_ffff,
+                }
+            } else {
+                0xffff_ffff
+            }
+        }
+        let efh = &self.efh;
+        let amd_physical_mode_mmio_size = self.amd_physical_mode_mmio_size;
+        let invalid_position = 0xffff_ffffu32;
+        let positions = match processor_generation {
+            Some(ProcessorGeneration::Milan) => [
+                efh.bhd_directory_table_milan()
+                    .ok()
+                    .unwrap_or(invalid_position),
+                invalid_position,
+                invalid_position,
+                invalid_position,
+            ],
+            Some(ProcessorGeneration::Rome) => [
+                de_mmio(
+                    efh.bhd_directory_tables[2].get(),
+                    amd_physical_mode_mmio_size,
+                ),
+                invalid_position,
+                invalid_position,
+                invalid_position,
+            ],
+            Some(ProcessorGeneration::Naples) => [
+                de_mmio(
+                    efh.bhd_directory_tables[0].get(),
+                    amd_physical_mode_mmio_size,
+                ),
+                invalid_position,
+                invalid_position,
+                invalid_position,
+            ],
+            None => [
+                // allow all (used for example for overlap checking)
+                efh.bhd_directory_table_milan()
+                    .ok()
+                    .unwrap_or(invalid_position),
+                de_mmio(
+                    efh.bhd_directory_tables[2].get(),
+                    amd_physical_mode_mmio_size,
+                ),
+                de_mmio(
+                    efh.bhd_directory_tables[1].get(),
+                    amd_physical_mode_mmio_size,
+                ),
+                de_mmio(
+                    efh.bhd_directory_tables[0].get(),
+                    amd_physical_mode_mmio_size,
+                ),
+            ],
+        };
+        Ok(EfhBhdsIterator {
+            storage: self.storage,
+            physical_address_mode: self.physical_address_mode(),
+            positions,
+            index_into_positions: 0,
+            amd_physical_mode_mmio_size: self.amd_physical_mode_mmio_size,
+        })
+    }
 
-	/// Return the directory matching PROCESSOR_GENERATION,
-	/// or any directory if that is None.
-	pub fn bhd_directory(
-		&self,
-		processor_generation: Option<ProcessorGeneration>,
-	) -> Result<BhdDirectory> {
-		if let Some(bhd_directory) = self
-			.bhd_directories(processor_generation)
-			.unwrap()
-			.next()
-		{
-			return Ok(bhd_directory);
-		}
-		Err(Error::BhdDirectoryHeaderNotFound)
-	}
+    /// Return the directory matching PROCESSOR_GENERATION,
+    /// or any directory if that is None.
+    pub fn bhd_directory(
+        &self,
+        processor_generation: Option<ProcessorGeneration>,
+    ) -> Result<BhdDirectory> {
+        if let Some(bhd_directory) =
+            self.bhd_directories(processor_generation).unwrap().next()
+        {
+            return Ok(bhd_directory);
+        }
+        Err(Error::BhdDirectoryHeaderNotFound)
+    }
 
-	fn write_efh(&mut self) -> Result<()> {
-		let mut buf: [u8; size_of::<Efh>()] =
-			[0xFF; size_of::<Efh>()];
-		if let Some(item) = header_from_collection_mut(&mut buf[..]) {
-			*item = self.efh;
-		}
+    fn write_efh(&mut self) -> Result<()> {
+        let mut buf: [u8; size_of::<Efh>()] = [0xFF; size_of::<Efh>()];
+        if let Some(item) = header_from_collection_mut(&mut buf[..]) {
+            *item = self.efh;
+        }
 
-		self.storage
-			.erase_and_write_blocks(self.efh_beginning, &buf)?;
-		Ok(())
-	}
+        self.storage.erase_and_write_blocks(self.efh_beginning, &buf)?;
+        Ok(())
+    }
 
-	pub fn spi_mode_bulldozer(&self) -> Result<EfhBulldozerSpiMode> {
-		self.efh.spi_mode_bulldozer()
-	}
-	pub fn set_spi_mode_bulldozer(&mut self, value: EfhBulldozerSpiMode) {
-		self.efh.set_spi_mode_bulldozer(value)
-		// FIXME: write_efh ?
-	}
-	pub fn spi_mode_zen_naples(&self) -> Result<EfhNaplesSpiMode> {
-		self.efh.spi_mode_zen_naples()
-	}
+    pub fn spi_mode_bulldozer(&self) -> Result<EfhBulldozerSpiMode> {
+        self.efh.spi_mode_bulldozer()
+    }
+    pub fn set_spi_mode_bulldozer(&mut self, value: EfhBulldozerSpiMode) {
+        self.efh.set_spi_mode_bulldozer(value)
+        // FIXME: write_efh ?
+    }
+    pub fn spi_mode_zen_naples(&self) -> Result<EfhNaplesSpiMode> {
+        self.efh.spi_mode_zen_naples()
+    }
 
-	pub fn set_spi_mode_zen_naples(&mut self, value: EfhNaplesSpiMode) {
-		self.efh.set_spi_mode_zen_naples(value)
-		// FIXME: write_efh ?
-	}
+    pub fn set_spi_mode_zen_naples(&mut self, value: EfhNaplesSpiMode) {
+        self.efh.set_spi_mode_zen_naples(value)
+        // FIXME: write_efh ?
+    }
 
-	pub fn spi_mode_zen_rome(&self) -> Result<EfhRomeSpiMode> {
-		self.efh.spi_mode_zen_rome()
-	}
+    pub fn spi_mode_zen_rome(&self) -> Result<EfhRomeSpiMode> {
+        self.efh.spi_mode_zen_rome()
+    }
 
-	pub fn set_spi_mode_zen_rome(&mut self, value: EfhRomeSpiMode) {
-		self.efh.set_spi_mode_zen_rome(value)
-		// FIXME: write_efh ?
-	}
+    pub fn set_spi_mode_zen_rome(&mut self, value: EfhRomeSpiMode) {
+        self.efh.set_spi_mode_zen_rome(value)
+        // FIXME: write_efh ?
+    }
 
-	/// Note: BEGINNING, END are coordinates (in Byte).
-	/// Note: We always create the directory and the contents adjacent, with gap in order to allow creating new directory entries when there are already contents.
-	pub fn create_bhd_directory(
-		&mut self,
-		beginning: ErasableLocation,
-		end: ErasableLocation,
-		default_entry_address_mode: AddressMode,
-		payloads_beginning: Option<ErasableLocation>,
-		entries: &[BhdDirectoryEntry],
-	) -> Result<BhdDirectory> {
-		match default_entry_address_mode {
-			AddressMode::PhysicalAddress => {
-				if !self.physical_address_mode() {
-					return Err(
-						Error::DirectoryTypeMismatch,
-					);
-				}
-			}
-			AddressMode::EfsRelativeOffset => {
-				if self.physical_address_mode() {
-					return Err(
-						Error::DirectoryTypeMismatch,
-					);
-				}
-			}
-			_ => return Err(Error::DirectoryTypeMismatch),
-		}
-		match self.bhd_directories(None) {
-			Ok(items) => {
-				for directory in items {
-					// TODO: Ensure that we don't have too many similar ones
-				}
-			}
-			Err(e) => {
-				return Err(e);
-			}
-		}
-		if self.efh.compatible_with_processor_generation(
-			ProcessorGeneration::Milan,
-		) {
-			self.efh.set_bhd_directory_table_milan(
-				beginning.into(),
-			);
-		// FIXME: ensure that the others are unset?
-		} else {
-			self.efh.bhd_directory_tables[2].set(beginning.into());
-			// FIXME: ensure that the others are unset?
-		}
-		self.write_efh()?;
-		let result = BhdDirectory::create(
-			default_entry_address_mode,
-			*b"$BHD",
-			self.amd_physical_mode_mmio_size,
-			payloads_beginning,
-			entries,
-		)?;
-		Ok(result)
-	}
+    /// Note: BEGINNING, END are coordinates (in Byte).
+    /// Note: We always create the directory and the contents adjacent, with gap in order to allow creating new directory entries when there are already contents.
+    pub fn create_bhd_directory(
+        &mut self,
+        beginning: ErasableLocation,
+        end: ErasableLocation,
+        default_entry_address_mode: AddressMode,
+        payloads_beginning: Option<ErasableLocation>,
+        entries: &[BhdDirectoryEntry],
+    ) -> Result<BhdDirectory> {
+        match default_entry_address_mode {
+            AddressMode::PhysicalAddress => {
+                if !self.physical_address_mode() {
+                    return Err(Error::DirectoryTypeMismatch);
+                }
+            }
+            AddressMode::EfsRelativeOffset => {
+                if self.physical_address_mode() {
+                    return Err(Error::DirectoryTypeMismatch);
+                }
+            }
+            _ => return Err(Error::DirectoryTypeMismatch),
+        }
+        match self.bhd_directories(None) {
+            Ok(items) => {
+                for directory in items {
+                    // TODO: Ensure that we don't have too many similar ones
+                }
+            }
+            Err(e) => {
+                return Err(e);
+            }
+        }
+        if self
+            .efh
+            .compatible_with_processor_generation(ProcessorGeneration::Milan)
+        {
+            self.efh.set_bhd_directory_table_milan(beginning.into());
+        // FIXME: ensure that the others are unset?
+        } else {
+            self.efh.bhd_directory_tables[2].set(beginning.into());
+            // FIXME: ensure that the others are unset?
+        }
+        self.write_efh()?;
+        let result = BhdDirectory::create(
+            default_entry_address_mode,
+            *b"$BHD",
+            self.amd_physical_mode_mmio_size,
+            payloads_beginning,
+            entries,
+        )?;
+        Ok(result)
+    }
 
-	// Note: BEGINNING, END are coordinates (in Byte).
-	pub fn create_psp_directory(
-		&mut self,
-		beginning: ErasableLocation,
-		end: ErasableLocation,
-		default_entry_address_mode: AddressMode,
-		payloads_beginning: Option<ErasableLocation>,
-		entries: &[PspDirectoryEntry],
-	) -> Result<PspDirectory> {
-		match default_entry_address_mode {
-			AddressMode::PhysicalAddress => {
-				if !self.physical_address_mode() {
-					return Err(
-						Error::DirectoryTypeMismatch,
-					);
-				}
-			}
-			AddressMode::EfsRelativeOffset => {
-				if self.physical_address_mode() {
-					return Err(
-						Error::DirectoryTypeMismatch,
-					);
-				}
-			}
-			_ => return Err(Error::DirectoryTypeMismatch),
-		}
-		match self.psp_directory() {
-			Err(Error::PspDirectoryHeaderNotFound) => {}
-			Err(e) => {
-				return Err(e);
-			}
-			Ok(_) => {
-				return Err(Error::Duplicate);
-			}
-		}
-		// TODO: Boards older than Rome have 0xff at the top bits.  Depends on address_mode maybe.
-		// Then, also psp_directory_table_location_naples should be set, instead.
-		self.efh.set_psp_directory_table_location_zen(beginning.into());
-		self.write_efh()?;
-		let result = PspDirectory::create(
-			default_entry_address_mode,
-			*b"$PSP",
-			self.amd_physical_mode_mmio_size,
-			payloads_beginning,
-			entries,
-		)?;
-		Ok(result)
-	}
+    // Note: BEGINNING, END are coordinates (in Byte).
+    pub fn create_psp_directory(
+        &mut self,
+        beginning: ErasableLocation,
+        end: ErasableLocation,
+        default_entry_address_mode: AddressMode,
+        payloads_beginning: Option<ErasableLocation>,
+        entries: &[PspDirectoryEntry],
+    ) -> Result<PspDirectory> {
+        match default_entry_address_mode {
+            AddressMode::PhysicalAddress => {
+                if !self.physical_address_mode() {
+                    return Err(Error::DirectoryTypeMismatch);
+                }
+            }
+            AddressMode::EfsRelativeOffset => {
+                if self.physical_address_mode() {
+                    return Err(Error::DirectoryTypeMismatch);
+                }
+            }
+            _ => return Err(Error::DirectoryTypeMismatch),
+        }
+        match self.psp_directory() {
+            Err(Error::PspDirectoryHeaderNotFound) => {}
+            Err(e) => {
+                return Err(e);
+            }
+            Ok(_) => {
+                return Err(Error::Duplicate);
+            }
+        }
+        // TODO: Boards older than Rome have 0xff at the top bits.  Depends on address_mode maybe.
+        // Then, also psp_directory_table_location_naples should be set, instead.
+        self.efh.set_psp_directory_table_location_zen(beginning.into());
+        self.write_efh()?;
+        let result = PspDirectory::create(
+            default_entry_address_mode,
+            *b"$PSP",
+            self.amd_physical_mode_mmio_size,
+            payloads_beginning,
+            entries,
+        )?;
+        Ok(result)
+    }
 
-	pub fn create_psp_subdirectory(
-		&self,
-		directory: &mut PspDirectory,
-		beginning: ErasableLocation,
-		end: ErasableLocation,
-		amd_physical_mode_mmio_size: Option<u32>,
-		payloads_beginning: Option<ErasableLocation>,
-		entries: &[PspDirectoryEntry],
-	) -> Result<PspDirectory> {
-		if directory.header.cookie() != *b"$PSP" {
-			return Err(Error::DirectoryTypeMismatch)
-		}
-// TODO
-//		if let Err(Error::EntryNotFound) = self.psp_subdirectory(directory) {
-			directory.add_entry_direct(
-				&mut PspDirectoryEntry::new_payload(
-					directory.directory_address_mode(),
-					PspDirectoryEntryType::SecondLevelDirectory,
-					Some(ErasableLocation::extent(beginning, end)),
-					Some(ValueOrLocation::EfsRelativeOffset(beginning.into())),
-				)?,
-			)?;
-			PspDirectory::create(
-				directory.directory_address_mode,
-				*b"$PL2",
-				amd_physical_mode_mmio_size,
-				payloads_beginning,
-				entries,
-			)
-//		} else {
-//			Err(Error::Duplicate)
-//		}
-	}
+    pub fn create_psp_subdirectory(
+        &self,
+        directory: &mut PspDirectory,
+        beginning: ErasableLocation,
+        end: ErasableLocation,
+        amd_physical_mode_mmio_size: Option<u32>,
+        payloads_beginning: Option<ErasableLocation>,
+        entries: &[PspDirectoryEntry],
+    ) -> Result<PspDirectory> {
+        if directory.header.cookie() != *b"$PSP" {
+            return Err(Error::DirectoryTypeMismatch);
+        }
+        // TODO
+        //		if let Err(Error::EntryNotFound) = self.psp_subdirectory(directory) {
+        directory.add_entry_direct(&mut PspDirectoryEntry::new_payload(
+            directory.directory_address_mode(),
+            PspDirectoryEntryType::SecondLevelDirectory,
+            Some(ErasableLocation::extent(beginning, end)),
+            Some(ValueOrLocation::EfsRelativeOffset(beginning.into())),
+        )?)?;
+        PspDirectory::create(
+            directory.directory_address_mode,
+            *b"$PL2",
+            amd_physical_mode_mmio_size,
+            payloads_beginning,
+            entries,
+        )
+        //		} else {
+        //			Err(Error::Duplicate)
+        //		}
+    }
 
-	pub fn create_second_level_psp_directory(
-		&self,
-		beginning: ErasableLocation,
-		end: ErasableLocation,
-		payloads_beginning: Option<ErasableLocation>,
-		entries: &[PspDirectoryEntry],
-	) -> Result<PspDirectory> {
-		let mut psp_directory = self.psp_directory()?;
-		self.create_psp_subdirectory(
-			&mut psp_directory,
-			beginning,
-			end,
-			self.amd_physical_mode_mmio_size,
-			payloads_beginning,
-			entries,
-		)
-	}
+    pub fn create_second_level_psp_directory(
+        &self,
+        beginning: ErasableLocation,
+        end: ErasableLocation,
+        payloads_beginning: Option<ErasableLocation>,
+        entries: &[PspDirectoryEntry],
+    ) -> Result<PspDirectory> {
+        let mut psp_directory = self.psp_directory()?;
+        self.create_psp_subdirectory(
+            &mut psp_directory,
+            beginning,
+            end,
+            self.amd_physical_mode_mmio_size,
+            payloads_beginning,
+            entries,
+        )
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,8 @@ pub use types::Result;
 
 #[cfg(test)]
 mod tests {
-	#[test]
-	fn it_works() {
-		assert_eq!(2 + 2, 4);
-	}
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
 }

--- a/src/ondisk.rs
+++ b/src/ondisk.rs
@@ -21,32 +21,31 @@ use zerocopy::{AsBytes, FromBytes, LayoutVerified, Unaligned, U32, U64};
 /// Given *BUF (a collection of multiple items), retrieves the first of the items and returns it.
 /// If the item cannot be parsed, returns None.
 pub fn header_from_collection_mut<'a, T: Sized + FromBytes + AsBytes>(
-	buf: &'a mut [u8],
+    buf: &'a mut [u8],
 ) -> Option<&'a mut T> {
-	match LayoutVerified::<_, T>::new_from_prefix(buf) {
-		Some((item, _xbuf)) => Some(item.into_mut()),
-		None => None,
-	}
+    match LayoutVerified::<_, T>::new_from_prefix(buf) {
+        Some((item, _xbuf)) => Some(item.into_mut()),
+        None => None,
+    }
 }
 
 /// Given *BUF (a collection of multiple items), retrieves the first of the items and returns it.
 /// If the item cannot be parsed, returns None.
 pub fn header_from_collection<'a, T: Sized + FromBytes>(
-	buf: &'a [u8],
+    buf: &'a [u8],
 ) -> Option<&'a T> {
-	match LayoutVerified::<_, T>::new_from_prefix(buf) {
-		Some((item, _xbuf)) => Some(item.into_ref()),
-		None => None,
-	}
+    match LayoutVerified::<_, T>::new_from_prefix(buf) {
+        Some((item, _xbuf)) => Some(item.into_ref()),
+        None => None,
+    }
 }
 
 type LU32 = U32<LittleEndian>;
 type LU64 = U64<LittleEndian>;
 
 // The first one is recommended by AMD; the last one is always used in practice.
-pub const EFH_POSITION: [Location; 6] = [
-	0xFA_0000, 0xF2_0000, 0xE2_0000, 0xC2_0000, 0x82_0000, 0x2_0000,
-];
+pub const EFH_POSITION: [Location; 6] =
+    [0xFA_0000, 0xF2_0000, 0xE2_0000, 0xC2_0000, 0x82_0000, 0x2_0000];
 
 #[repr(u8)]
 #[derive(Debug, PartialEq, FromPrimitive, ToPrimitive, Clone, Copy)]
@@ -54,14 +53,14 @@ pub const EFH_POSITION: [Location; 6] = [
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub enum SpiReadMode {
-	Normal33_33Mhz = 0b000, // up to 33.33 MHz
-	Dual112 = 0b010,
-	Quad114 = 0b011,
-	Dual122 = 0b100,
-	Quad144 = 0b101,
-	Normal66_66Mhz = 0b110, // up to 66.66 MHz
-	Fast = 0b111,
-	DoNothing = 0xff,
+    Normal33_33Mhz = 0b000, // up to 33.33 MHz
+    Dual112 = 0b010,
+    Quad114 = 0b011,
+    Dual122 = 0b100,
+    Quad144 = 0b101,
+    Normal66_66Mhz = 0b110, // up to 66.66 MHz
+    Fast = 0b111,
+    DoNothing = 0xff,
 }
 
 #[repr(u8)]
@@ -70,45 +69,45 @@ pub enum SpiReadMode {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub enum SpiFastSpeedNew {
-	_66_66MHz = 0,
-	_33_33MHz = 1,
-	_22_22MHz = 2,
-	_16_66MHz = 3,
-	_100MHz = 0b100,
-	_800kHz = 0b101,
-	DoNothing = 0xff,
+    _66_66MHz = 0,
+    _33_33MHz = 1,
+    _22_22MHz = 2,
+    _16_66MHz = 3,
+    _100MHz = 0b100,
+    _800kHz = 0b101,
+    DoNothing = 0xff,
 }
 
 make_accessors! {
-	#[derive(FromBytes, AsBytes, Unaligned, Clone, Copy, Debug)]
-	#[repr(C, packed)]
-	pub struct EfhBulldozerSpiMode {
-		read_mode: u8 : pub get SpiReadMode : pub set SpiReadMode,
-		fast_speed_new: u8 : pub get SpiFastSpeedNew : pub set SpiFastSpeedNew,
-		_reserved: u8,
-	}
+    #[derive(FromBytes, AsBytes, Unaligned, Clone, Copy, Debug)]
+    #[repr(C, packed)]
+    pub struct EfhBulldozerSpiMode {
+        read_mode: u8 : pub get SpiReadMode : pub set SpiReadMode,
+        fast_speed_new: u8 : pub get SpiFastSpeedNew : pub set SpiFastSpeedNew,
+        _reserved: u8,
+    }
 }
 
 impl Default for EfhBulldozerSpiMode {
-	fn default() -> Self {
-		Self {
-			read_mode: 0xff,
-			fast_speed_new: 0xff,
-			_reserved: 0xff, // FIXME: check
-		}
-	}
+    fn default() -> Self {
+        Self {
+            read_mode: 0xff,
+            fast_speed_new: 0xff,
+            _reserved: 0xff, // FIXME: check
+        }
+    }
 }
 
 impl Getter<Result<EfhBulldozerSpiMode>> for EfhBulldozerSpiMode {
-	fn get1(self) -> Result<Self> {
-		Ok(self)
-	}
+    fn get1(self) -> Result<Self> {
+        Ok(self)
+    }
 }
 
 impl Setter<EfhBulldozerSpiMode> for EfhBulldozerSpiMode {
-	fn set1(&mut self, value: Self) {
-		*self = value
-	}
+    fn set1(&mut self, value: Self) {
+        *self = value
+    }
 }
 
 #[repr(u8)]
@@ -117,52 +116,48 @@ impl Setter<EfhBulldozerSpiMode> for EfhBulldozerSpiMode {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub enum SpiNaplesMicronMode {
-	DummyCycle = 0x0a,
-	DoNothing = 0xff,
+    DummyCycle = 0x0a,
+    DoNothing = 0xff,
 }
 
 make_accessors! {
-	#[derive(FromBytes, AsBytes, Unaligned, Clone, Copy, Debug)]
-	#[repr(C, packed)]
-	pub struct EfhNaplesSpiMode {
-		read_mode: u8 : pub get SpiReadMode : pub set SpiReadMode,
-		fast_speed_new: u8 : pub get SpiFastSpeedNew : pub set SpiFastSpeedNew,
-		micron_mode: u8 : pub get SpiNaplesMicronMode : pub set SpiNaplesMicronMode,
-	}
+    #[derive(FromBytes, AsBytes, Unaligned, Clone, Copy, Debug)]
+    #[repr(C, packed)]
+    pub struct EfhNaplesSpiMode {
+        read_mode: u8 : pub get SpiReadMode : pub set SpiReadMode,
+        fast_speed_new: u8 : pub get SpiFastSpeedNew : pub set SpiFastSpeedNew,
+        micron_mode: u8 : pub get SpiNaplesMicronMode : pub set SpiNaplesMicronMode,
+    }
 }
 
 impl Default for EfhNaplesSpiMode {
-	fn default() -> Self {
-		Self {
-			read_mode: 0xff,
-			fast_speed_new: 0xff,
-			micron_mode: 0xff,
-		}
-	}
+    fn default() -> Self {
+        Self { read_mode: 0xff, fast_speed_new: 0xff, micron_mode: 0xff }
+    }
 }
 
 impl Getter<Result<EfhNaplesSpiMode>> for EfhNaplesSpiMode {
-	fn get1(self) -> Result<Self> {
-		Ok(self)
-	}
+    fn get1(self) -> Result<Self> {
+        Ok(self)
+    }
 }
 
 impl Setter<EfhNaplesSpiMode> for EfhNaplesSpiMode {
-	fn set1(&mut self, value: EfhNaplesSpiMode) {
-		*self = value
-	}
+    fn set1(&mut self, value: EfhNaplesSpiMode) {
+        *self = value
+    }
 }
 
 impl Getter<Result<EfhRomeSpiMode>> for EfhRomeSpiMode {
-	fn get1(self) -> Result<Self> {
-		Ok(self)
-	}
+    fn get1(self) -> Result<Self> {
+        Ok(self)
+    }
 }
 
 impl Setter<EfhRomeSpiMode> for EfhRomeSpiMode {
-	fn set1(&mut self, value: EfhRomeSpiMode) {
-		*self = value
-	}
+    fn set1(&mut self, value: EfhRomeSpiMode) {
+        *self = value
+    }
 }
 
 #[repr(u8)]
@@ -171,342 +166,333 @@ impl Setter<EfhRomeSpiMode> for EfhRomeSpiMode {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub enum SpiRomeMicronMode {
-	SupportMicron = 0x55,
-	ForceMicron = 0xaa,
-	DoNothing = 0xff,
+    SupportMicron = 0x55,
+    ForceMicron = 0xaa,
+    DoNothing = 0xff,
 }
 
 make_accessors! {
-	#[derive(FromBytes, AsBytes, Unaligned, Clone, Copy, Debug)]
-	#[repr(C, packed)]
-	pub struct EfhRomeSpiMode {
-		read_mode: u8 : pub get SpiReadMode : pub set SpiReadMode,
-		fast_speed_new: u8 : pub get SpiFastSpeedNew : pub set SpiFastSpeedNew,
-		micron_mode: u8 : pub get SpiRomeMicronMode : pub set SpiRomeMicronMode,
-	}
+    #[derive(FromBytes, AsBytes, Unaligned, Clone, Copy, Debug)]
+    #[repr(C, packed)]
+    pub struct EfhRomeSpiMode {
+        read_mode: u8 : pub get SpiReadMode : pub set SpiReadMode,
+        fast_speed_new: u8 : pub get SpiFastSpeedNew : pub set SpiFastSpeedNew,
+        micron_mode: u8 : pub get SpiRomeMicronMode : pub set SpiRomeMicronMode,
+    }
 }
 
 impl Default for EfhRomeSpiMode {
-	fn default() -> Self {
-		Self {
-			read_mode: 0xff,
-			fast_speed_new: 0xff,
-			micron_mode: 0x55,
-		}
-	}
+    fn default() -> Self {
+        Self { read_mode: 0xff, fast_speed_new: 0xff, micron_mode: 0x55 }
+    }
 }
 
 make_accessors! {
-	#[derive(FromBytes, AsBytes, Unaligned, Clone, Copy, Debug)]
-	#[repr(C, packed)]
-	pub struct Efh {
-		signature: LU32 : pub get u32 : pub set u32,                           // 0x55aa_55aa
-		imc_fw_location: LU32 : pub get u32 : pub set u32,                     // usually unused
-		gbe_fw_location: LU32 : pub get u32 : pub set u32,                     // usually unused
-		xhci_fw_location: LU32 : pub get u32 : pub set u32,                    // usually unused
-		psp_directory_table_location_naples: LU32 : pub get u32 : pub set u32, // usually unused
-		psp_directory_table_location_zen: LU32 : pub get u32 : pub set u32,
-		/// High nibble of model number is either 0 (Naples), 1 (Raven Ridge), or 3 (Rome).  Then, corresponding indices into BHD_DIRECTORY_TABLES are 0, 1, 2, respectively.  Newer models always use BHD_DIRECTORY_TABLE_MILAN instead.
-		pub bhd_directory_tables: [LU32; 3],
-		pub(crate) efs_generations: LU32, // bit 0: All pointers are Flash MMIO pointers; should be clear for Rome; bit 1: Clear for Milan
-		bhd_directory_table_milan: LU32 : pub get u32 : pub set u32, // or Combo
-		_padding: LU32,
-		promontory_firmware_location: LU32 : pub get u32 : pub set u32,
-		pub low_power_promontory_firmware_location: LU32 : pub get u32 : pub set u32,
-		_padding2: [LU32; 2],                      // at offset 0x38
-		spi_mode_bulldozer: EfhBulldozerSpiMode : pub get EfhBulldozerSpiMode : pub set EfhBulldozerSpiMode,
-		spi_mode_zen_naples: EfhNaplesSpiMode : pub get EfhNaplesSpiMode : pub set EfhNaplesSpiMode, // and Raven Ridge
-		spi_mode_zen_rome: EfhRomeSpiMode : pub get EfhRomeSpiMode : pub set EfhRomeSpiMode,
-		_reserved2: u8,
-	}
+    #[derive(FromBytes, AsBytes, Unaligned, Clone, Copy, Debug)]
+    #[repr(C, packed)]
+    pub struct Efh {
+        signature: LU32 : pub get u32 : pub set u32,                           // 0x55aa_55aa
+        imc_fw_location: LU32 : pub get u32 : pub set u32,                     // usually unused
+        gbe_fw_location: LU32 : pub get u32 : pub set u32,                     // usually unused
+        xhci_fw_location: LU32 : pub get u32 : pub set u32,                    // usually unused
+        psp_directory_table_location_naples: LU32 : pub get u32 : pub set u32, // usually unused
+        psp_directory_table_location_zen: LU32 : pub get u32 : pub set u32,
+        /// High nibble of model number is either 0 (Naples), 1 (Raven Ridge), or 3 (Rome).  Then, corresponding indices into BHD_DIRECTORY_TABLES are 0, 1, 2, respectively.  Newer models always use BHD_DIRECTORY_TABLE_MILAN instead.
+        pub bhd_directory_tables: [LU32; 3],
+        pub(crate) efs_generations: LU32, // bit 0: All pointers are Flash MMIO pointers; should be clear for Rome; bit 1: Clear for Milan
+        bhd_directory_table_milan: LU32 : pub get u32 : pub set u32, // or Combo
+        _padding: LU32,
+        promontory_firmware_location: LU32 : pub get u32 : pub set u32,
+        pub low_power_promontory_firmware_location: LU32 : pub get u32 : pub set u32,
+        _padding2: [LU32; 2],                      // at offset 0x38
+        spi_mode_bulldozer: EfhBulldozerSpiMode : pub get EfhBulldozerSpiMode : pub set EfhBulldozerSpiMode,
+        spi_mode_zen_naples: EfhNaplesSpiMode : pub get EfhNaplesSpiMode : pub set EfhNaplesSpiMode, // and Raven Ridge
+        spi_mode_zen_rome: EfhRomeSpiMode : pub get EfhRomeSpiMode : pub set EfhRomeSpiMode,
+        _reserved2: u8,
+    }
 }
 
 impl Default for Efh {
-	fn default() -> Self {
-		Self {
-			signature: 0x55aa_55aa.into(),
-			imc_fw_location: 0.into(),
-			gbe_fw_location: 0.into(),
-			xhci_fw_location: 0.into(),
-			psp_directory_table_location_naples: 0.into(),
-			psp_directory_table_location_zen: 0.into(), // probably invalid
-			bhd_directory_tables: [0.into(); 3],        // probably invalid
-			efs_generations: 0xffff_fffe.into(),
-			bhd_directory_table_milan: 0xffff_ffff.into(),
-			_padding: 0xffff_ffff.into(),
-			promontory_firmware_location: 0xffff_ffff.into(),
-			low_power_promontory_firmware_location: 0xffff_ffff
-				.into(),
-			_padding2: [0xffff_ffff.into(); 2],
-			spi_mode_bulldozer: EfhBulldozerSpiMode::default(),
-			spi_mode_zen_naples: EfhNaplesSpiMode::default(),
-			spi_mode_zen_rome: EfhRomeSpiMode::default(),
-			_reserved2: 0,
-		}
-	}
+    fn default() -> Self {
+        Self {
+            signature: 0x55aa_55aa.into(),
+            imc_fw_location: 0.into(),
+            gbe_fw_location: 0.into(),
+            xhci_fw_location: 0.into(),
+            psp_directory_table_location_naples: 0.into(),
+            psp_directory_table_location_zen: 0.into(), // probably invalid
+            bhd_directory_tables: [0.into(); 3],        // probably invalid
+            efs_generations: 0xffff_fffe.into(),
+            bhd_directory_table_milan: 0xffff_ffff.into(),
+            _padding: 0xffff_ffff.into(),
+            promontory_firmware_location: 0xffff_ffff.into(),
+            low_power_promontory_firmware_location: 0xffff_ffff.into(),
+            _padding2: [0xffff_ffff.into(); 2],
+            spi_mode_bulldozer: EfhBulldozerSpiMode::default(),
+            spi_mode_zen_naples: EfhNaplesSpiMode::default(),
+            spi_mode_zen_rome: EfhRomeSpiMode::default(),
+            _reserved2: 0,
+        }
+    }
 }
 
 #[repr(i8)]
 #[derive(
-	Debug,
-	PartialEq,
-	FromPrimitive,
-	Clone,
-	Copy,
-	EnumString,
-	strum_macros::EnumIter,
+    Debug,
+    PartialEq,
+    FromPrimitive,
+    Clone,
+    Copy,
+    EnumString,
+    strum_macros::EnumIter,
 )]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum ProcessorGeneration {
-	Naples = -1,
-	Rome = 0,
-	Milan = 1,
+    Naples = -1,
+    Rome = 0,
+    Milan = 1,
 }
 
 impl Efh {
-	/// Precondition: signature needs to be there--otherwise you might be reading garbage in the first place.
-	/// Old (pre-Rome) boards had MMIO addresses instead of offsets in the slots.  Find out whether that's the case.
-	pub fn second_gen_efs(&self) -> bool {
-		self.efs_generations.get() & 1 == 0
-	}
+    /// Precondition: signature needs to be there--otherwise you might be reading garbage in the first place.
+    /// Old (pre-Rome) boards had MMIO addresses instead of offsets in the slots.  Find out whether that's the case.
+    pub fn second_gen_efs(&self) -> bool {
+        self.efs_generations.get() & 1 == 0
+    }
 
-	/// Precondition: signature needs to be there--otherwise you might be reading garbage in the first place.
-	/// Old (pre-Rome) boards had MMIO addresses instead of offsets in the slots.  Find out whether that's the case.
-	pub fn physical_address_mode(&self) -> bool {
-		!self.second_gen_efs()
-	}
-	/// Precondition: signature needs to be there--otherwise you might be reading garbage in the first place.
-	/// Note: generation 1 is Milan
-	pub fn compatible_with_processor_generation(
-		&self,
-		generation: ProcessorGeneration,
-	) -> bool {
-		match generation {
-			ProcessorGeneration::Naples => {
-				// Naples didn't have generation flags yet, so make sure none of them are cleared.
-				// Naples didn't have normal (non-MMIO) offsets yet--so those also should be unavailable.
-				self.efs_generations.get() == 0xffff_ffff
-			}
-			ProcessorGeneration::Rome => {
-				// Rome didn't have generation flags yet, so make sure none of them are cleared.
-				self.efs_generations.get() == 0xffff_fffe
-			}
-			generation => {
-				let generation: u8 = generation as u8;
-				assert!(generation < 16);
-				self.efs_generations.get() & (1 << generation) ==
-					0
-			}
-		}
-	}
+    /// Precondition: signature needs to be there--otherwise you might be reading garbage in the first place.
+    /// Old (pre-Rome) boards had MMIO addresses instead of offsets in the slots.  Find out whether that's the case.
+    pub fn physical_address_mode(&self) -> bool {
+        !self.second_gen_efs()
+    }
+    /// Precondition: signature needs to be there--otherwise you might be reading garbage in the first place.
+    /// Note: generation 1 is Milan
+    pub fn compatible_with_processor_generation(
+        &self,
+        generation: ProcessorGeneration,
+    ) -> bool {
+        match generation {
+            ProcessorGeneration::Naples => {
+                // Naples didn't have generation flags yet, so make sure none of them are cleared.
+                // Naples didn't have normal (non-MMIO) offsets yet--so those also should be unavailable.
+                self.efs_generations.get() == 0xffff_ffff
+            }
+            ProcessorGeneration::Rome => {
+                // Rome didn't have generation flags yet, so make sure none of them are cleared.
+                self.efs_generations.get() == 0xffff_fffe
+            }
+            generation => {
+                let generation: u8 = generation as u8;
+                assert!(generation < 16);
+                self.efs_generations.get() & (1 << generation) == 0
+            }
+        }
+    }
 
-	pub fn efs_generations_for_processor_generation(
-		generation: ProcessorGeneration,
-	) -> u32 {
-		match generation {
-			// Naples didn't have normal (non-MMIO) offsets yet--so mark them unavailable.
-			ProcessorGeneration::Naples => 0xffff_ffff,
-			// Rome didn't have generation flags yet, so make sure to clear none of them.
-			ProcessorGeneration::Rome => 0xffff_fffe,
-			generation => {
-				let generation: u8 = generation as u8;
-				assert!(generation < 16);
-				0xffff_fffe & !(1 << generation)
-			}
-		}
-	}
+    pub fn efs_generations_for_processor_generation(
+        generation: ProcessorGeneration,
+    ) -> u32 {
+        match generation {
+            // Naples didn't have normal (non-MMIO) offsets yet--so mark them unavailable.
+            ProcessorGeneration::Naples => 0xffff_ffff,
+            // Rome didn't have generation flags yet, so make sure to clear none of them.
+            ProcessorGeneration::Rome => 0xffff_fffe,
+            generation => {
+                let generation: u8 = generation as u8;
+                assert!(generation < 16);
+                0xffff_fffe & !(1 << generation)
+            }
+        }
+    }
 }
 
 #[derive(
-	Debug, PartialEq, Eq, FromPrimitive, Clone, Copy, BitfieldSpecifier,
+    Debug, PartialEq, Eq, FromPrimitive, Clone, Copy, BitfieldSpecifier,
 )]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum AddressMode {
-	/// Only supported for images <= 16 MiB.
-	/// Right-justified in 4 GiB address space.
-	/// Only really used in families older than Rome.
-	PhysicalAddress = 0,
-	EfsRelativeOffset = 1,       // x
-	DirectoryRelativeOffset = 2, // (x - Base)
-	EntryRelativeOffset = 3, // x; ImageBaseRelativeOffset == DirectoryRelativeOffset; not Base
+    /// Only supported for images <= 16 MiB.
+    /// Right-justified in 4 GiB address space.
+    /// Only really used in families older than Rome.
+    PhysicalAddress = 0,
+    EfsRelativeOffset = 1,       // x
+    DirectoryRelativeOffset = 2, // (x - Base)
+    EntryRelativeOffset = 3, // x; ImageBaseRelativeOffset == DirectoryRelativeOffset; not Base
 }
 
 pub(crate) const WEAK_ADDRESS_MODE: AddressMode =
-	AddressMode::DirectoryRelativeOffset;
+    AddressMode::DirectoryRelativeOffset;
 
 impl DummyErrorChecks for AddressMode {}
 
 pub enum ValueOrLocation {
-	Value(u64),
-	PhysicalAddress(u32),
-	EfsRelativeOffset(u32),
-	DirectoryRelativeOffset(u32),
-	EntryRelativeOffset(u32),
+    Value(u64),
+    PhysicalAddress(u32),
+    EfsRelativeOffset(u32),
+    DirectoryRelativeOffset(u32),
+    EntryRelativeOffset(u32),
 }
 
 impl core::fmt::Debug for ValueOrLocation {
-	fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-		match *self {
-			Self::Value(x) => write!(fmt, "Value({:x?})", x),
-			Self::PhysicalAddress(x) => {
-				write!(fmt, "PhysicalAddress({:#x?})", x)
-			}
-			Self::EfsRelativeOffset(x) => {
-				write!(fmt, "EfsRelativeOffset({:#x?})", x)
-			}
-			Self::DirectoryRelativeOffset(x) => write!(
-				fmt,
-				"DirectoryRelativeOffset({:#x?})",
-				x
-			),
-			Self::EntryRelativeOffset(x) => {
-				write!(fmt, "EntryRelativeOffset({:#x?})", x)
-			}
-		}
-	}
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match *self {
+            Self::Value(x) => write!(fmt, "Value({:x?})", x),
+            Self::PhysicalAddress(x) => {
+                write!(fmt, "PhysicalAddress({:#x?})", x)
+            }
+            Self::EfsRelativeOffset(x) => {
+                write!(fmt, "EfsRelativeOffset({:#x?})", x)
+            }
+            Self::DirectoryRelativeOffset(x) => {
+                write!(fmt, "DirectoryRelativeOffset({:#x?})", x)
+            }
+            Self::EntryRelativeOffset(x) => {
+                write!(fmt, "EntryRelativeOffset({:#x?})", x)
+            }
+        }
+    }
 }
 
 pub(crate) fn mmio_encode(
-	value: Location,
-	amd_physical_mode_mmio_size: Option<u32>,
+    value: Location,
+    amd_physical_mode_mmio_size: Option<u32>,
 ) -> Result<u32> {
-	let mmio_address_lower = match amd_physical_mode_mmio_size {
-		None | Some(0) => return Err(Error::DirectoryTypeMismatch),
-		Some(x) => 1 + (0xFFFF_FFFFu32 - x),
-	};
-	Ok(value.checked_add(mmio_address_lower)
-		.ok_or(Error::DirectoryTypeMismatch)?)
+    let mmio_address_lower = match amd_physical_mode_mmio_size {
+        None | Some(0) => return Err(Error::DirectoryTypeMismatch),
+        Some(x) => 1 + (0xFFFF_FFFFu32 - x),
+    };
+    Ok(value
+        .checked_add(mmio_address_lower)
+        .ok_or(Error::DirectoryTypeMismatch)?)
 }
 
 pub(crate) fn mmio_decode(
-	value: u32,
-	amd_physical_mode_mmio_size: u32,
+    value: u32,
+    amd_physical_mode_mmio_size: u32,
 ) -> Result<u32> {
-	let mmio_address_lower = match amd_physical_mode_mmio_size {
-		0 => return Err(Error::DirectoryTypeMismatch),
-		x => 1 + (0xFFFF_FFFFu32 - x),
-	};
-	if value >= mmio_address_lower {
-		Ok(value - mmio_address_lower)
-	} else {
-		Err(Error::DirectoryTypeMismatch)
-	}
+    let mmio_address_lower = match amd_physical_mode_mmio_size {
+        0 => return Err(Error::DirectoryTypeMismatch),
+        x => 1 + (0xFFFF_FFFFu32 - x),
+    };
+    if value >= mmio_address_lower {
+        Ok(value - mmio_address_lower)
+    } else {
+        Err(Error::DirectoryTypeMismatch)
+    }
 }
 
 impl ValueOrLocation {
-	fn effective_address_mode(directory_address_mode: AddressMode, entry_address_mode: AddressMode) -> AddressMode {
-		if directory_address_mode == WEAK_ADDRESS_MODE {
-			entry_address_mode
-		} else {
-			directory_address_mode
-		}
-	}
-	fn is_entry_address_mode_effective(directory_address_mode: AddressMode, entry_address_mode: AddressMode) -> bool {
-		Self::effective_address_mode(directory_address_mode, entry_address_mode) == entry_address_mode
-	}
+    fn effective_address_mode(
+        directory_address_mode: AddressMode,
+        entry_address_mode: AddressMode,
+    ) -> AddressMode {
+        if directory_address_mode == WEAK_ADDRESS_MODE {
+            entry_address_mode
+        } else {
+            directory_address_mode
+        }
+    }
+    fn is_entry_address_mode_effective(
+        directory_address_mode: AddressMode,
+        entry_address_mode: AddressMode,
+    ) -> bool {
+        Self::effective_address_mode(directory_address_mode, entry_address_mode)
+            == entry_address_mode
+    }
 
-	pub(crate) fn new_from_raw_location(
-		directory_address_mode: AddressMode,
-		source: u64,
-	) -> Result<Self> {
-		let entry_address_mode = (source & 0xC000_0000_0000_0000) >> 62;
-		let entry_address_mode =
-			AddressMode::from_u64(entry_address_mode).unwrap();
-		let value = u32::try_from(source & !0xC000_0000_0000_0000)
-			.map_err(|_| Error::DirectoryPayloadRangeCheck)?;
-		let address_mode = Self::effective_address_mode(
-			directory_address_mode,
-			entry_address_mode
-		);
-		Ok(match address_mode {
-			AddressMode::PhysicalAddress => {
-				Self::PhysicalAddress(value)
-			}
-			AddressMode::EfsRelativeOffset => {
-				Self::EfsRelativeOffset(value)
-			}
-			AddressMode::DirectoryRelativeOffset => {
-				Self::DirectoryRelativeOffset(value)
-			}
-			AddressMode::EntryRelativeOffset => {
-				Self::EntryRelativeOffset(value)
-			}
-		})
-	}
+    pub(crate) fn new_from_raw_location(
+        directory_address_mode: AddressMode,
+        source: u64,
+    ) -> Result<Self> {
+        let entry_address_mode = (source & 0xC000_0000_0000_0000) >> 62;
+        let entry_address_mode =
+            AddressMode::from_u64(entry_address_mode).unwrap();
+        let value = u32::try_from(source & !0xC000_0000_0000_0000)
+            .map_err(|_| Error::DirectoryPayloadRangeCheck)?;
+        let address_mode = Self::effective_address_mode(
+            directory_address_mode,
+            entry_address_mode,
+        );
+        Ok(match address_mode {
+            AddressMode::PhysicalAddress => Self::PhysicalAddress(value),
+            AddressMode::EfsRelativeOffset => Self::EfsRelativeOffset(value),
+            AddressMode::DirectoryRelativeOffset => {
+                Self::DirectoryRelativeOffset(value)
+            }
+            AddressMode::EntryRelativeOffset => {
+                Self::EntryRelativeOffset(value)
+            }
+        })
+    }
 
-	pub(crate) fn try_into_raw_location(
-		&self,
-		directory_address_mode: AddressMode,
-	) -> Result<u64> {
-		match self {
-			ValueOrLocation::Value(_) => {
-				Err(Error::EntryTypeMismatch)
-			}
-			ValueOrLocation::PhysicalAddress(x) => {
-				if Self::is_entry_address_mode_effective(
-					directory_address_mode,
-					AddressMode::PhysicalAddress
-				) {
-					// AMD retrofitted (introduced) two
-					// flag bits at the top bits in Milan.
-					//
-					// In Rome, you actually COULD use
-					// all the bits.
-					//
-					// Newer platform do not regularily use
-					// AddressMode::PhysicalAddress anyway.
-					//
-					// But if someone uses
-					// AddressMode::PhysicalAddress,
-					// they might do it on Rome and use
-					// those two top bits as part of the
-					// address.
-					let v = u64::from(*x);
-					Ok(v)
-				} else {
-					Err(Error::EntryTypeMismatch)
-				}
-			}
-			ValueOrLocation::EfsRelativeOffset(x) => {
-				if Self::is_entry_address_mode_effective(
-					directory_address_mode,
-					AddressMode::EfsRelativeOffset
-				) {
-					let v = u64::from(*x) |
-						0x4000_0000_0000_0000;
-					Ok(v)
-				} else {
-					Err(Error::EntryTypeMismatch)
-				}
-			}
-			ValueOrLocation::DirectoryRelativeOffset(x) => {
-				if Self::is_entry_address_mode_effective(
-					directory_address_mode,
-					AddressMode::DirectoryRelativeOffset
-				) {
-					let v = u64::from(*x) |
-						0x8000_0000_0000_0000;
-					Ok(v)
-				} else {
-					Err(Error::EntryTypeMismatch)
-				}
-			}
-			ValueOrLocation::EntryRelativeOffset(x) => {
-				if Self::is_entry_address_mode_effective(
-					directory_address_mode,
-					AddressMode::EntryRelativeOffset
-				) {
-					let v = u64::from(*x) |
-						0xC000_0000_0000_0000;
-					Ok(v)
-				} else {
-					Err(Error::EntryTypeMismatch)
-				}
-			}
-		}
-	}
+    pub(crate) fn try_into_raw_location(
+        &self,
+        directory_address_mode: AddressMode,
+    ) -> Result<u64> {
+        match self {
+            ValueOrLocation::Value(_) => Err(Error::EntryTypeMismatch),
+            ValueOrLocation::PhysicalAddress(x) => {
+                if Self::is_entry_address_mode_effective(
+                    directory_address_mode,
+                    AddressMode::PhysicalAddress,
+                ) {
+                    // AMD retrofitted (introduced) two
+                    // flag bits at the top bits in Milan.
+                    //
+                    // In Rome, you actually COULD use
+                    // all the bits.
+                    //
+                    // Newer platform do not regularily use
+                    // AddressMode::PhysicalAddress anyway.
+                    //
+                    // But if someone uses
+                    // AddressMode::PhysicalAddress,
+                    // they might do it on Rome and use
+                    // those two top bits as part of the
+                    // address.
+                    let v = u64::from(*x);
+                    Ok(v)
+                } else {
+                    Err(Error::EntryTypeMismatch)
+                }
+            }
+            ValueOrLocation::EfsRelativeOffset(x) => {
+                if Self::is_entry_address_mode_effective(
+                    directory_address_mode,
+                    AddressMode::EfsRelativeOffset,
+                ) {
+                    let v = u64::from(*x) | 0x4000_0000_0000_0000;
+                    Ok(v)
+                } else {
+                    Err(Error::EntryTypeMismatch)
+                }
+            }
+            ValueOrLocation::DirectoryRelativeOffset(x) => {
+                if Self::is_entry_address_mode_effective(
+                    directory_address_mode,
+                    AddressMode::DirectoryRelativeOffset,
+                ) {
+                    let v = u64::from(*x) | 0x8000_0000_0000_0000;
+                    Ok(v)
+                } else {
+                    Err(Error::EntryTypeMismatch)
+                }
+            }
+            ValueOrLocation::EntryRelativeOffset(x) => {
+                if Self::is_entry_address_mode_effective(
+                    directory_address_mode,
+                    AddressMode::EntryRelativeOffset,
+                ) {
+                    let v = u64::from(*x) | 0xC000_0000_0000_0000;
+                    Ok(v)
+                } else {
+                    Err(Error::EntryTypeMismatch)
+                }
+            }
+        }
+    }
 }
 
 /// XXX: If I move this to struct_accessors, it doesn't work anymore.
@@ -561,153 +547,150 @@ macro_rules! make_bitfield_serde {(
 }}
 
 make_bitfield_serde! {
-	#[bitfield(bits = 32)]
-	#[repr(u32)]
-	#[derive(Copy, Clone, Debug)]
-	pub struct DirectoryAdditionalInfo {
-		pub max_size: B10 : pub get u16 : pub set u16, // directory size in 4 kiB; Note: doc error in AMD docs // TODO: Shrink setter.
-		#[skip(getters, setters)]
-		spi_block_size: B4, // spi block size in 4 kiB; Note: 0 = 64 kiB
-		pub base_address: B15 : pub get u16 : pub set u16, // base address in 4 kiB; if the actual payload (the file contents) of the directory are somewhere else, this can specify where. // TODO: Shrink setter.
-		#[bits = 2]
-		pub address_mode: AddressMode : pub get AddressMode : pub set AddressMode, // FIXME: This should not be able to be changed (from/to 2 at least) as you are iterating over a directory--since the iterator has to interpret what it is reading relative to this setting // TODO: Shrink setter.
-		#[skip]
-		__: bool,
-	}
+    #[bitfield(bits = 32)]
+    #[repr(u32)]
+    #[derive(Copy, Clone, Debug)]
+    pub struct DirectoryAdditionalInfo {
+        pub max_size: B10 : pub get u16 : pub set u16, // directory size in 4 kiB; Note: doc error in AMD docs // TODO: Shrink setter.
+        #[skip(getters, setters)]
+        spi_block_size: B4, // spi block size in 4 kiB; Note: 0 = 64 kiB
+        pub base_address: B15 : pub get u16 : pub set u16, // base address in 4 kiB; if the actual payload (the file contents) of the directory are somewhere else, this can specify where. // TODO: Shrink setter.
+        #[bits = 2]
+        pub address_mode: AddressMode : pub get AddressMode : pub set AddressMode, // FIXME: This should not be able to be changed (from/to 2 at least) as you are iterating over a directory--since the iterator has to interpret what it is reading relative to this setting // TODO: Shrink setter.
+        #[skip]
+        __: bool,
+    }
 }
 
 impl Default for DirectoryAdditionalInfo {
-	fn default() -> Self {
-		Self::new()
-	}
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl DirectoryAdditionalInfo {
-	pub const UNIT: usize = 4096; // Byte
-	pub fn with_spi_block_size_checked(
-		&mut self,
-		value: u16,
-	) -> core::result::Result<Self, modular_bitfield::error::OutOfBounds> {
-		let mut result = *self;
-		result.set_spi_block_size_checked(value)?;
-		Ok(result)
-	}
-	pub fn spi_block_size_or_err(
-		&self,
-	) -> core::result::Result<
-		u16,
-		modular_bitfield::error::InvalidBitPattern<u8>,
-	> {
-		let spi_block_size = ((u32::from(*self) >> 10) & 0xf) as u16;
-		match spi_block_size {
-			0 => Ok(0x10), // 64 kiB
-			n => Ok(n),
-		}
-	}
-	pub fn spi_block_size(&self) -> u16 {
-		self.spi_block_size_or_err().unwrap()
-	}
-	pub fn set_spi_block_size_checked(
-		&mut self,
-		value: u16,
-	) -> core::result::Result<(), modular_bitfield::error::OutOfBounds> {
-		let mut mask = u32::from(*self) & !0b1111_0000000000;
-		if value > 0 && value <= 15 {
-			mask |= (value as u32) << 10;
-		} else if value == 16 { // 64 kiB
-		} else {
-			return Err(modular_bitfield::error::OutOfBounds);
-		}
-		*self = Self::from(mask);
-		Ok(())
-	}
-	/// Given a value, tries to convert it into UNIT without loss.  If that's not possible, returns None
-	pub fn try_into_unit(value: usize) -> Option<u16> {
-		if value % Self::UNIT == 0 {
-			let value = value / Self::UNIT;
-			Some(value.try_into().ok()?)
-		} else {
-			None
-		}
-	}
-	pub fn try_from_unit(value: u16) -> Option<usize> {
-		let result: usize = value.try_into().ok()?;
-		result.checked_mul(Self::UNIT)
-	}
+    pub const UNIT: usize = 4096; // Byte
+    pub fn with_spi_block_size_checked(
+        &mut self,
+        value: u16,
+    ) -> core::result::Result<Self, modular_bitfield::error::OutOfBounds> {
+        let mut result = *self;
+        result.set_spi_block_size_checked(value)?;
+        Ok(result)
+    }
+    pub fn spi_block_size_or_err(
+        &self,
+    ) -> core::result::Result<u16, modular_bitfield::error::InvalidBitPattern<u8>>
+    {
+        let spi_block_size = ((u32::from(*self) >> 10) & 0xf) as u16;
+        match spi_block_size {
+            0 => Ok(0x10), // 64 kiB
+            n => Ok(n),
+        }
+    }
+    pub fn spi_block_size(&self) -> u16 {
+        self.spi_block_size_or_err().unwrap()
+    }
+    pub fn set_spi_block_size_checked(
+        &mut self,
+        value: u16,
+    ) -> core::result::Result<(), modular_bitfield::error::OutOfBounds> {
+        let mut mask = u32::from(*self) & !0b1111_0000000000;
+        if value > 0 && value <= 15 {
+            mask |= (value as u32) << 10;
+        } else if value == 16 { // 64 kiB
+        } else {
+            return Err(modular_bitfield::error::OutOfBounds);
+        }
+        *self = Self::from(mask);
+        Ok(())
+    }
+    /// Given a value, tries to convert it into UNIT without loss.  If that's not possible, returns None
+    pub fn try_into_unit(value: usize) -> Option<u16> {
+        if value % Self::UNIT == 0 {
+            let value = value / Self::UNIT;
+            Some(value.try_into().ok()?)
+        } else {
+            None
+        }
+    }
+    pub fn try_from_unit(value: u16) -> Option<usize> {
+        let result: usize = value.try_into().ok()?;
+        result.checked_mul(Self::UNIT)
+    }
 }
 
 pub trait DirectoryHeader {
-	fn cookie(&self) -> [u8; 4];
-	fn set_cookie(&mut self, value: [u8; 4]);
-	fn additional_info(&self) -> DirectoryAdditionalInfo;
-	fn set_additional_info(&mut self, value: DirectoryAdditionalInfo);
-	fn total_entries(&self) -> u32;
-	fn set_total_entries(&mut self, value: u32);
-	fn checksum(&self) -> u32;
-	fn set_checksum(&mut self, value: u32);
+    fn cookie(&self) -> [u8; 4];
+    fn set_cookie(&mut self, value: [u8; 4]);
+    fn additional_info(&self) -> DirectoryAdditionalInfo;
+    fn set_additional_info(&mut self, value: DirectoryAdditionalInfo);
+    fn total_entries(&self) -> u32;
+    fn set_total_entries(&mut self, value: u32);
+    fn checksum(&self) -> u32;
+    fn set_checksum(&mut self, value: u32);
 }
 
 #[derive(FromBytes, AsBytes, Unaligned, Clone, Copy)]
 #[repr(C, packed)]
 pub struct PspDirectoryHeader {
-	pub(crate) cookie: [u8; 4], // b"$PSP" or b"$PL2"
-	pub(crate) checksum: LU32, // 32-bit CRC value of header below this field and including all entries
-	pub(crate) total_entries: LU32,
-	pub(crate) additional_info: LU32, // 0xffff_ffff; or DirectoryAdditionalInfo
+    pub(crate) cookie: [u8; 4], // b"$PSP" or b"$PL2"
+    pub(crate) checksum: LU32, // 32-bit CRC value of header below this field and including all entries
+    pub(crate) total_entries: LU32,
+    pub(crate) additional_info: LU32, // 0xffff_ffff; or DirectoryAdditionalInfo
 }
 
 impl DirectoryHeader for PspDirectoryHeader {
-	fn cookie(&self) -> [u8; 4] {
-		self.cookie
-	}
-	fn set_cookie(&mut self, value: [u8; 4]) {
-		self.cookie = value;
-	}
-	fn additional_info(&self) -> DirectoryAdditionalInfo {
-		DirectoryAdditionalInfo::from(self.additional_info.get())
-	}
-	fn set_additional_info(&mut self, value: DirectoryAdditionalInfo) {
-		self.additional_info.set(value.into())
-	}
-	fn total_entries(&self) -> u32 {
-		self.total_entries.get()
-	}
-	fn set_total_entries(&mut self, value: u32) {
-		self.total_entries.set(value)
-	}
-	fn checksum(&self) -> u32 {
-		self.checksum.get()
-	}
-	fn set_checksum(&mut self, value: u32) {
-		self.checksum.set(value)
-	}
+    fn cookie(&self) -> [u8; 4] {
+        self.cookie
+    }
+    fn set_cookie(&mut self, value: [u8; 4]) {
+        self.cookie = value;
+    }
+    fn additional_info(&self) -> DirectoryAdditionalInfo {
+        DirectoryAdditionalInfo::from(self.additional_info.get())
+    }
+    fn set_additional_info(&mut self, value: DirectoryAdditionalInfo) {
+        self.additional_info.set(value.into())
+    }
+    fn total_entries(&self) -> u32 {
+        self.total_entries.get()
+    }
+    fn set_total_entries(&mut self, value: u32) {
+        self.total_entries.set(value)
+    }
+    fn checksum(&self) -> u32 {
+        self.checksum.get()
+    }
+    fn set_checksum(&mut self, value: u32) {
+        self.checksum.set(value)
+    }
 }
 
 impl Default for PspDirectoryHeader {
-	fn default() -> Self {
-		Self {
-			cookie: *b"    ",   // invalid
-			checksum: 0.into(), // invalid
-			total_entries: 0.into(),
-			additional_info: 0xffff_ffff.into(), // invalid
-		}
-	}
+    fn default() -> Self {
+        Self {
+            cookie: *b"    ",   // invalid
+            checksum: 0.into(), // invalid
+            total_entries: 0.into(),
+            additional_info: 0xffff_ffff.into(), // invalid
+        }
+    }
 }
 
 impl core::fmt::Debug for PspDirectoryHeader {
-	fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-		let checksum = self.checksum.get();
-		let total_entries = self.total_entries.get();
-		let additional_info = DirectoryAdditionalInfo::from(
-			self.additional_info.get(),
-		);
-		fmt.debug_struct("PspDirectoryHeader")
-			.field("cookie", &self.cookie)
-			.field("checksum", &checksum)
-			.field("total_entries", &total_entries)
-			.field("additional_info", &additional_info)
-			.finish()
-	}
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let checksum = self.checksum.get();
+        let total_entries = self.total_entries.get();
+        let additional_info =
+            DirectoryAdditionalInfo::from(self.additional_info.get());
+        fmt.debug_struct("PspDirectoryHeader")
+            .field("cookie", &self.cookie)
+            .field("checksum", &checksum)
+            .field("total_entries", &total_entries)
+            .field("additional_info", &additional_info)
+            .finish()
+    }
 }
 
 #[repr(u8)]
@@ -717,87 +700,87 @@ impl core::fmt::Debug for PspDirectoryHeader {
 #[bits = 8]
 #[non_exhaustive]
 pub enum PspDirectoryEntryType {
-	AmdPublicKey = 0x00,
-	PspBootloader = 0x01,
-	PspOs = 0x02,
-	PspRecoveryBootloader = 0x03,
-	PspNvdata = 0x04,
-	SmuOffChipFirmware8 = 0x08,
-	AmdSecureDebugKey = 0x09,
-	AblPublicKey = 0x0A,
-	PspSoftFuseChain = 0x0B,
-	PspTrustlets = 0x0C,
-	PspTrustletPublicKey = 0x0D,
-	SmuOffChipFirmware12 = 0x12,
-	PspEarlySecureUnlockDebugImage = 0x13,
-	DiscoveryBinary = 0x20,
-	WrappedIkek = 0x21,
-	PspTokenUnlockData = 0x22,
-	SecurityPolicyBinary = 0x24,
-	Mp2Firmware = 0x25,
-	Mp2Firmware2 = 0x26,
-	UserModeUnitTests = 0x27,
-	PspSystemDriverEntryPoints = 0x28,
-	KvmImage = 0x29,
-	Mp5Firmware = 0x2A,
-	EfsPhysAddr = 0x2B,
-	TeeWriteOnceNvram = 0x2C,
-	ExternalChipsetPspBootLoader2d = 0x2D,
-	ExternalChipsetMp0Dxio = 0x2E,
-	ExternalChipsetMp1Firmware = 0x2F,
-	Abl0 = 0x30,
-	Abl1 = 0x31,
-	Abl2 = 0x32,
-	Abl3 = 0x33,
-	Abl4 = 0x34,
-	Abl5 = 0x35,
-	Abl6 = 0x36,
-	Abl7 = 0x37,
-	SevData = 0x38,
-	SevCode = 0x39,
-	PpinWhiteListBinary = 0x3A,
-	SerdesPhyMicrocode = 0x3B,
-	VbiosPreload = 0x3C,
-	WlanUmac = 0x3D,
-	WlanImac = 0x3E,
-	WlanBluetooth = 0x3F,
-	SecondLevelDirectory = 0x40,
-	ExternalChipsetMp0Bootloader = 0x41,
-	DxioPhySramFirmware = 0x42,
-	DxioPhySramPublicKey = 0x43,
-	UsbUnifiedPhyFirmware = 0x44,
-	TosSecurityPolicyBinary = 0x45,
-	ExternalChipsetPspBootloader46 = 0x46,
-	DrtmTa = 0x47,
-	L2aPspDirectory = 0x48,
-	L2BhdDirectory = 0x49,
-	L2bPspDirectory = 0x4A,
-	ExternalChipsetSecurityPolicyBinary = 0x4C,
-	ExternalChipsetSecureDebugUnlockBinary = 0x4D,
-	PmuPublicKey = 0x4E,
-	UmcFirmware = 0x4F,
-	PspBootloaderPublicKeysTable = 0x50,
-	PspTosPublicKeysTable = 0x51,
-	PspBootloaderUserApplication = 0x52,
-	PspBootloaderUserApplicationPublicKey = 0x53,
-	PspRpmcNvram = 0x54,
-	BootloaderSplTable = 0x55, // used by boot ROM
-	TosSplTable = 0x56,        // used by off-chip bootloader
-	PspBootloaderCvipConfigurationTable = 0x57,
-	DmcuEram = 0x58,
-	DmcuIsr = 0x59,
-	Msmu0 = 0x5A,
-	Msmu1 = 0x5B,
-	OemSysTa = 0x80,
-	OemSysTaPublicKey = 0x81,
-	OemIkek = 0x82,
-	OemSplTable = 0x83, // used by customer-signed binary
-	OemTkek = 0x84,
-	AmfFirmwarePart1 = 0x85,
-	AmfFirmwarePart2 = 0x86,
-	MpmFactoryProvisioningData = 0x87,
-	MpmWlanFirmware = 0x88,
-	MpmSecurityDriver = 0x89,
+    AmdPublicKey = 0x00,
+    PspBootloader = 0x01,
+    PspOs = 0x02,
+    PspRecoveryBootloader = 0x03,
+    PspNvdata = 0x04,
+    SmuOffChipFirmware8 = 0x08,
+    AmdSecureDebugKey = 0x09,
+    AblPublicKey = 0x0A,
+    PspSoftFuseChain = 0x0B,
+    PspTrustlets = 0x0C,
+    PspTrustletPublicKey = 0x0D,
+    SmuOffChipFirmware12 = 0x12,
+    PspEarlySecureUnlockDebugImage = 0x13,
+    DiscoveryBinary = 0x20,
+    WrappedIkek = 0x21,
+    PspTokenUnlockData = 0x22,
+    SecurityPolicyBinary = 0x24,
+    Mp2Firmware = 0x25,
+    Mp2Firmware2 = 0x26,
+    UserModeUnitTests = 0x27,
+    PspSystemDriverEntryPoints = 0x28,
+    KvmImage = 0x29,
+    Mp5Firmware = 0x2A,
+    EfsPhysAddr = 0x2B,
+    TeeWriteOnceNvram = 0x2C,
+    ExternalChipsetPspBootLoader2d = 0x2D,
+    ExternalChipsetMp0Dxio = 0x2E,
+    ExternalChipsetMp1Firmware = 0x2F,
+    Abl0 = 0x30,
+    Abl1 = 0x31,
+    Abl2 = 0x32,
+    Abl3 = 0x33,
+    Abl4 = 0x34,
+    Abl5 = 0x35,
+    Abl6 = 0x36,
+    Abl7 = 0x37,
+    SevData = 0x38,
+    SevCode = 0x39,
+    PpinWhiteListBinary = 0x3A,
+    SerdesPhyMicrocode = 0x3B,
+    VbiosPreload = 0x3C,
+    WlanUmac = 0x3D,
+    WlanImac = 0x3E,
+    WlanBluetooth = 0x3F,
+    SecondLevelDirectory = 0x40,
+    ExternalChipsetMp0Bootloader = 0x41,
+    DxioPhySramFirmware = 0x42,
+    DxioPhySramPublicKey = 0x43,
+    UsbUnifiedPhyFirmware = 0x44,
+    TosSecurityPolicyBinary = 0x45,
+    ExternalChipsetPspBootloader46 = 0x46,
+    DrtmTa = 0x47,
+    L2aPspDirectory = 0x48,
+    L2BhdDirectory = 0x49,
+    L2bPspDirectory = 0x4A,
+    ExternalChipsetSecurityPolicyBinary = 0x4C,
+    ExternalChipsetSecureDebugUnlockBinary = 0x4D,
+    PmuPublicKey = 0x4E,
+    UmcFirmware = 0x4F,
+    PspBootloaderPublicKeysTable = 0x50,
+    PspTosPublicKeysTable = 0x51,
+    PspBootloaderUserApplication = 0x52,
+    PspBootloaderUserApplicationPublicKey = 0x53,
+    PspRpmcNvram = 0x54,
+    BootloaderSplTable = 0x55, // used by boot ROM
+    TosSplTable = 0x56,        // used by off-chip bootloader
+    PspBootloaderCvipConfigurationTable = 0x57,
+    DmcuEram = 0x58,
+    DmcuIsr = 0x59,
+    Msmu0 = 0x5A,
+    Msmu1 = 0x5B,
+    OemSysTa = 0x80,
+    OemSysTaPublicKey = 0x81,
+    OemIkek = 0x82,
+    OemSplTable = 0x83, // used by customer-signed binary
+    OemTkek = 0x84,
+    AmfFirmwarePart1 = 0x85,
+    AmfFirmwarePart2 = 0x86,
+    MpmFactoryProvisioningData = 0x87,
+    MpmWlanFirmware = 0x88,
+    MpmSecurityDriver = 0x89,
 }
 
 impl DummyErrorChecks for PspDirectoryEntryType {}
@@ -808,8 +791,8 @@ impl DummyErrorChecks for PspDirectoryEntryType {}
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[bits = 1]
 pub enum PspSoftFuseChain32MiBSpiDecoding {
-	LowerHalf = 0,
-	UpperHalf = 1,
+    LowerHalf = 0,
+    UpperHalf = 1,
 }
 
 impl DummyErrorChecks for PspSoftFuseChain32MiBSpiDecoding {}
@@ -819,45 +802,45 @@ impl DummyErrorChecks for PspSoftFuseChain32MiBSpiDecoding {}
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[bits = 1]
 pub enum PspSoftFuseChainPostCodeDecoding {
-	Lpc = 0,
-	Espi = 1,
+    Lpc = 0,
+    Espi = 1,
 }
 
 impl DummyErrorChecks for PspSoftFuseChainPostCodeDecoding {}
 
 make_bitfield_serde! {
-	#[bitfield(bits = 64)]
-	#[repr(u64)]
-	#[derive(Copy, Clone, Debug)]
-	pub struct PspSoftFuseChain {
-		pub secure_debug_unlock: bool : pub get bool : pub set bool,
-		#[skip]
-		__: bool,
-		pub early_secure_debug_unlock: bool : pub get bool : pub set bool,
-		pub unlock_token_in_nvram: bool : pub get bool : pub set bool, // if the unlock token has been stored (by us) into NVRAM
-		pub force_security_policy_loading_even_if_insecure: bool : pub get bool : pub set bool,
-		pub load_diagnostic_bootloader: bool : pub get bool : pub set bool,
-		pub disable_psp_debug_prints: bool : pub get bool : pub set bool,
-		#[skip]
-		__: B7,
-		pub spi_decoding: PspSoftFuseChain32MiBSpiDecoding : pub get PspSoftFuseChain32MiBSpiDecoding : pub set PspSoftFuseChain32MiBSpiDecoding,
-		pub postcode_decoding: PspSoftFuseChainPostCodeDecoding : pub get PspSoftFuseChainPostCodeDecoding : pub set PspSoftFuseChainPostCodeDecoding,
-		#[skip]
-		__: B12,
-		#[skip]
-		__: bool,
-		pub skip_mp2_firmware_loading: bool : pub get bool : pub set bool,
-		pub postcode_output_control_1byte: bool : pub get bool : pub set bool, // ???
-		pub force_recovery_booting: bool : pub get bool : pub set bool,
-		#[skip]
-		__: B32,
-	}
+    #[bitfield(bits = 64)]
+    #[repr(u64)]
+    #[derive(Copy, Clone, Debug)]
+    pub struct PspSoftFuseChain {
+        pub secure_debug_unlock: bool : pub get bool : pub set bool,
+        #[skip]
+        __: bool,
+        pub early_secure_debug_unlock: bool : pub get bool : pub set bool,
+        pub unlock_token_in_nvram: bool : pub get bool : pub set bool, // if the unlock token has been stored (by us) into NVRAM
+        pub force_security_policy_loading_even_if_insecure: bool : pub get bool : pub set bool,
+        pub load_diagnostic_bootloader: bool : pub get bool : pub set bool,
+        pub disable_psp_debug_prints: bool : pub get bool : pub set bool,
+        #[skip]
+        __: B7,
+        pub spi_decoding: PspSoftFuseChain32MiBSpiDecoding : pub get PspSoftFuseChain32MiBSpiDecoding : pub set PspSoftFuseChain32MiBSpiDecoding,
+        pub postcode_decoding: PspSoftFuseChainPostCodeDecoding : pub get PspSoftFuseChainPostCodeDecoding : pub set PspSoftFuseChainPostCodeDecoding,
+        #[skip]
+        __: B12,
+        #[skip]
+        __: bool,
+        pub skip_mp2_firmware_loading: bool : pub get bool : pub set bool,
+        pub postcode_output_control_1byte: bool : pub get bool : pub set bool, // ???
+        pub force_recovery_booting: bool : pub get bool : pub set bool,
+        #[skip]
+        __: B32,
+    }
 }
 
 impl Default for PspSoftFuseChain {
-	fn default() -> Self {
-		Self::new()
-	}
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 #[repr(u8)]
@@ -867,16 +850,16 @@ impl Default for PspSoftFuseChain {
 #[bits = 2]
 #[non_exhaustive]
 pub enum PspDirectoryRomId {
-	SpiCs1 = 0,
-	SpiCs2 = 1,
+    SpiCs1 = 0,
+    SpiCs2 = 1,
 }
 
 impl DummyErrorChecks for PspDirectoryRomId {}
 
 impl Default for PspDirectoryRomId {
-	fn default() -> Self {
-		Self::SpiCs1
-	}
+    fn default() -> Self {
+        Self::SpiCs1
+    }
 }
 
 #[repr(u8)]
@@ -886,273 +869,265 @@ impl Default for PspDirectoryRomId {
 #[bits = 2]
 #[non_exhaustive]
 pub enum BhdDirectoryRomId {
-	SpiCs1 = 0,
-	SpiCs2 = 1,
+    SpiCs1 = 0,
+    SpiCs2 = 1,
 }
 
 impl DummyErrorChecks for BhdDirectoryRomId {}
 
 impl Default for BhdDirectoryRomId {
-	fn default() -> Self {
-		Self::SpiCs1
-	}
+    fn default() -> Self {
+        Self::SpiCs1
+    }
 }
 
 make_bitfield_serde! {
-	#[derive(Clone, Copy)]
-	#[bitfield(bits = 32)]
-	#[repr(u32)]
-	pub struct PspDirectoryEntryAttrs {
-		#[bits = 8]
-		#[allow(non_snake_case)]
-		pub type_: PspDirectoryEntryType : pub get PspDirectoryEntryType : pub set PspDirectoryEntryType,
-		pub sub_program: B8 : pub get u8 : pub set u8, // function of AMD Family and Model; only useful for types 8, 0x24, 0x25
-		pub rom_id: PspDirectoryRomId : pub get PspDirectoryRomId : pub set PspDirectoryRomId,
-		#[skip]
-		__: B14,
-	}
+    #[derive(Clone, Copy)]
+    #[bitfield(bits = 32)]
+    #[repr(u32)]
+    pub struct PspDirectoryEntryAttrs {
+        #[bits = 8]
+        #[allow(non_snake_case)]
+        pub type_: PspDirectoryEntryType : pub get PspDirectoryEntryType : pub set PspDirectoryEntryType,
+        pub sub_program: B8 : pub get u8 : pub set u8, // function of AMD Family and Model; only useful for types 8, 0x24, 0x25
+        pub rom_id: PspDirectoryRomId : pub get PspDirectoryRomId : pub set PspDirectoryRomId,
+        #[skip]
+        __: B14,
+    }
 }
 
 make_accessors! {
-	#[derive(FromBytes, AsBytes, Unaligned, Clone, Copy)]
-	#[repr(C, packed)]
-	pub struct PspDirectoryEntry {
-		pub(crate) attrs: LU32,
-		pub(crate) internal_size: LU32,
-		pub(crate) internal_source: LU64, // Note: value iff size == 0; otherwise location; TODO: (iff directory.address_mode == 2) entry address mode (top 2 bits), or 0
-	}
+    #[derive(FromBytes, AsBytes, Unaligned, Clone, Copy)]
+    #[repr(C, packed)]
+    pub struct PspDirectoryEntry {
+        pub(crate) attrs: LU32,
+        pub(crate) internal_size: LU32,
+        pub(crate) internal_source: LU64, // Note: value iff size == 0; otherwise location; TODO: (iff directory.address_mode == 2) entry address mode (top 2 bits), or 0
+    }
 }
 
 // TODO: Remove.
 impl Default for PspDirectoryEntry {
-	fn default() -> Self {
-		Self {
-			attrs: 0.into(),
-			internal_size: 0.into(),
-			internal_source: 0.into(),
-		}
-	}
+    fn default() -> Self {
+        Self {
+            attrs: 0.into(),
+            internal_size: 0.into(),
+            internal_source: 0.into(),
+        }
+    }
 }
 
 pub trait DirectoryEntry {
-	fn source(
-		&self,
-		directory_address_mode: AddressMode,
-	) -> Result<ValueOrLocation>;
-	fn size(&self) -> Option<u32>;
-	/// Note: This can also modify size as a side effect.
-	fn set_source(
-		&mut self,
-		directory_address_mode: AddressMode,
-		value: ValueOrLocation,
-	) -> Result<()>;
-	fn set_size(&mut self, value: Option<u32>);
+    fn source(
+        &self,
+        directory_address_mode: AddressMode,
+    ) -> Result<ValueOrLocation>;
+    fn size(&self) -> Option<u32>;
+    /// Note: This can also modify size as a side effect.
+    fn set_source(
+        &mut self,
+        directory_address_mode: AddressMode,
+        value: ValueOrLocation,
+    ) -> Result<()>;
+    fn set_size(&mut self, value: Option<u32>);
 }
 pub trait DirectoryEntrySerde: Sized {
-	fn from_slice(source: &[u8]) -> Option<Self>;
-	fn copy_into_slice(&self, destination: &mut [u8]);
+    fn from_slice(source: &[u8]) -> Option<Self>;
+    fn copy_into_slice(&self, destination: &mut [u8]);
 }
 impl DirectoryEntrySerde for PspDirectoryEntry {
-	fn from_slice(source: &[u8]) -> Option<Self> {
-		let result = LayoutVerified::<_, Self>::new_unaligned(source)?;
-		Some(*result.into_ref())
-	}
-	fn copy_into_slice(&self, destination: &mut [u8]) {
-		destination.copy_from_slice(&self.as_bytes())
-	}
+    fn from_slice(source: &[u8]) -> Option<Self> {
+        let result = LayoutVerified::<_, Self>::new_unaligned(source)?;
+        Some(*result.into_ref())
+    }
+    fn copy_into_slice(&self, destination: &mut [u8]) {
+        destination.copy_from_slice(&self.as_bytes())
+    }
 }
 
 impl PspDirectoryEntry {
-	const SIZE_VALUE_MARKER: u32 = 0xFFFF_FFFF;
-	pub fn type_or_err(&self) -> Result<PspDirectoryEntryType> {
-		let attrs = PspDirectoryEntryAttrs::from(self.attrs.get());
-		attrs.type__or_err().map_err(|_| Error::EntryTypeMismatch)
-	}
-	pub fn new() -> Self {
-		Self::default()
-	}
-	pub fn with_type_(&mut self, value: PspDirectoryEntryType) -> &mut Self {
-		let mut attrs = PspDirectoryEntryAttrs::from(self.attrs.get());
-		attrs.set_type_(value);
-		self.attrs.set(u32::from_le_bytes(attrs.into_bytes()));
-		self
-	}
-	pub fn type_(&self) -> PspDirectoryEntryType {
-		let attrs = PspDirectoryEntryAttrs::from(self.attrs.get());
-		attrs.type_()
-	}
-	pub fn with_sub_program(&mut self, value: u8) -> &mut Self {
-		let mut attrs = PspDirectoryEntryAttrs::from(self.attrs.get());
-		attrs.set_sub_program(value);
-		self.attrs.set(u32::from_le_bytes(attrs.into_bytes()));
-		self
-	}
-	pub fn with_rom_id(&mut self, value: PspDirectoryRomId) -> &mut Self {
-		let mut attrs = PspDirectoryEntryAttrs::from(self.attrs.get());
-		attrs.set_rom_id(value);
-		self.attrs.set(u32::from_le_bytes(attrs.into_bytes()));
-		self
-	}
-	/// Note: Caller can modify other attributes using the with_ accessors.
-	pub fn new_value(
-		type_: PspDirectoryEntryType,
-		value: u64,
-	) -> Result<Self> {
-		let mut result = Self::new()
-			.with_type_(type_.into())
-			.build();
-		result.internal_size = Self::SIZE_VALUE_MARKER.into();
-		result.internal_source = value.into();
-		Ok(result)
-	}
-	/// Note: Caller can modify other attributes using the with_ accessors.
-	pub fn new_payload(
-		directory_address_mode: AddressMode,
-		type_: PspDirectoryEntryType,
-		size: Option<u32>,
-		source: Option<ValueOrLocation>,
-	) -> Result<Self> {
-		let mut result = Self::new().with_type_(type_.into()).build();
-		result.set_size(size);
-		if let Some(x) = source {
-			result.set_source(directory_address_mode, x)?;
-		}
-		Ok(result)
-	}
+    const SIZE_VALUE_MARKER: u32 = 0xFFFF_FFFF;
+    pub fn type_or_err(&self) -> Result<PspDirectoryEntryType> {
+        let attrs = PspDirectoryEntryAttrs::from(self.attrs.get());
+        attrs.type__or_err().map_err(|_| Error::EntryTypeMismatch)
+    }
+    pub fn new() -> Self {
+        Self::default()
+    }
+    pub fn with_type_(&mut self, value: PspDirectoryEntryType) -> &mut Self {
+        let mut attrs = PspDirectoryEntryAttrs::from(self.attrs.get());
+        attrs.set_type_(value);
+        self.attrs.set(u32::from_le_bytes(attrs.into_bytes()));
+        self
+    }
+    pub fn type_(&self) -> PspDirectoryEntryType {
+        let attrs = PspDirectoryEntryAttrs::from(self.attrs.get());
+        attrs.type_()
+    }
+    pub fn with_sub_program(&mut self, value: u8) -> &mut Self {
+        let mut attrs = PspDirectoryEntryAttrs::from(self.attrs.get());
+        attrs.set_sub_program(value);
+        self.attrs.set(u32::from_le_bytes(attrs.into_bytes()));
+        self
+    }
+    pub fn with_rom_id(&mut self, value: PspDirectoryRomId) -> &mut Self {
+        let mut attrs = PspDirectoryEntryAttrs::from(self.attrs.get());
+        attrs.set_rom_id(value);
+        self.attrs.set(u32::from_le_bytes(attrs.into_bytes()));
+        self
+    }
+    /// Note: Caller can modify other attributes using the with_ accessors.
+    pub fn new_value(type_: PspDirectoryEntryType, value: u64) -> Result<Self> {
+        let mut result = Self::new().with_type_(type_.into()).build();
+        result.internal_size = Self::SIZE_VALUE_MARKER.into();
+        result.internal_source = value.into();
+        Ok(result)
+    }
+    /// Note: Caller can modify other attributes using the with_ accessors.
+    pub fn new_payload(
+        directory_address_mode: AddressMode,
+        type_: PspDirectoryEntryType,
+        size: Option<u32>,
+        source: Option<ValueOrLocation>,
+    ) -> Result<Self> {
+        let mut result = Self::new().with_type_(type_.into()).build();
+        result.set_size(size);
+        if let Some(x) = source {
+            result.set_source(directory_address_mode, x)?;
+        }
+        Ok(result)
+    }
 }
 
 impl DirectoryEntry for PspDirectoryEntry {
-	fn source(
-		&self,
-		directory_address_mode: AddressMode,
-	) -> Result<ValueOrLocation> {
-		let source = self.internal_source.get();
-		let size = self.internal_size.get();
-		if size == Self::SIZE_VALUE_MARKER {
-			Ok(ValueOrLocation::Value(source))
-		} else {
-			ValueOrLocation::new_from_raw_location(
-				directory_address_mode,
-				source,
-			)
-		}
-	}
-	fn set_source(
-		&mut self,
-		directory_address_mode: AddressMode,
-		value: ValueOrLocation,
-	) -> Result<()> {
-		match value {
-			ValueOrLocation::Value(v) => {
-				self.internal_size.set(Self::SIZE_VALUE_MARKER);
-				self.internal_source.set(v);
-				Ok(())
-			}
-			x => {
-				let v = x.try_into_raw_location(
-					directory_address_mode,
-				)?;
-				self.internal_source.set(v);
-				Ok(())
-			}
-		}
-	}
-	fn size(&self) -> Option<u32> {
-		let size = self.internal_size.get();
-		if size == Self::SIZE_VALUE_MARKER {
-			None
-		} else {
-			Some(size)
-		}
-	}
-	fn set_size(&mut self, value: Option<u32>) {
-		self.internal_size.set(match value {
-			None => Self::SIZE_VALUE_MARKER,
-			Some(x) => {
-				assert!(x != Self::SIZE_VALUE_MARKER);
-				x
-			}
-		})
-	}
+    fn source(
+        &self,
+        directory_address_mode: AddressMode,
+    ) -> Result<ValueOrLocation> {
+        let source = self.internal_source.get();
+        let size = self.internal_size.get();
+        if size == Self::SIZE_VALUE_MARKER {
+            Ok(ValueOrLocation::Value(source))
+        } else {
+            ValueOrLocation::new_from_raw_location(
+                directory_address_mode,
+                source,
+            )
+        }
+    }
+    fn set_source(
+        &mut self,
+        directory_address_mode: AddressMode,
+        value: ValueOrLocation,
+    ) -> Result<()> {
+        match value {
+            ValueOrLocation::Value(v) => {
+                self.internal_size.set(Self::SIZE_VALUE_MARKER);
+                self.internal_source.set(v);
+                Ok(())
+            }
+            x => {
+                let v = x.try_into_raw_location(directory_address_mode)?;
+                self.internal_source.set(v);
+                Ok(())
+            }
+        }
+    }
+    fn size(&self) -> Option<u32> {
+        let size = self.internal_size.get();
+        if size == Self::SIZE_VALUE_MARKER {
+            None
+        } else {
+            Some(size)
+        }
+    }
+    fn set_size(&mut self, value: Option<u32>) {
+        self.internal_size.set(match value {
+            None => Self::SIZE_VALUE_MARKER,
+            Some(x) => {
+                assert!(x != Self::SIZE_VALUE_MARKER);
+                x
+            }
+        })
+    }
 }
 
 impl core::fmt::Debug for PspDirectoryEntry {
-	fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-		// DirectoryRelativeOffset (WEAK_ADDRESS_MODE) is the only one that's always overridable.
-		let source = self.source(WEAK_ADDRESS_MODE);
-		let size = self.size();
-		let attrs = PspDirectoryEntryAttrs::from(self.attrs.get());
-		fmt.debug_struct("PspDirectoryEntry")
-			.field("type_", &attrs.type__or_err())
-			.field("sub_program", &attrs.sub_program_or_err())
-			.field("rom_id", &attrs.rom_id_or_err())
-			.field("size", &size)
-			.field("source", &source)
-			.finish()
-	}
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // DirectoryRelativeOffset (WEAK_ADDRESS_MODE) is the only one that's always overridable.
+        let source = self.source(WEAK_ADDRESS_MODE);
+        let size = self.size();
+        let attrs = PspDirectoryEntryAttrs::from(self.attrs.get());
+        fmt.debug_struct("PspDirectoryEntry")
+            .field("type_", &attrs.type__or_err())
+            .field("sub_program", &attrs.sub_program_or_err())
+            .field("rom_id", &attrs.rom_id_or_err())
+            .field("size", &size)
+            .field("source", &source)
+            .finish()
+    }
 }
 
 #[derive(FromBytes, AsBytes, Unaligned, Clone, Copy)]
 #[repr(C, packed)]
 pub struct BhdDirectoryHeader {
-	pub(crate) cookie: [u8; 4], // b"$BHD" or b"$BL2"
-	pub(crate) checksum: LU32, // 32-bit CRC value of header below this field and including all entries
-	pub(crate) total_entries: LU32,
-	pub(crate) additional_info: LU32,
+    pub(crate) cookie: [u8; 4], // b"$BHD" or b"$BL2"
+    pub(crate) checksum: LU32, // 32-bit CRC value of header below this field and including all entries
+    pub(crate) total_entries: LU32,
+    pub(crate) additional_info: LU32,
 }
 
 impl DirectoryHeader for BhdDirectoryHeader {
-	fn cookie(&self) -> [u8; 4] {
-		self.cookie
-	}
-	fn set_cookie(&mut self, value: [u8; 4]) {
-		self.cookie = value;
-	}
-	fn additional_info(&self) -> DirectoryAdditionalInfo {
-		DirectoryAdditionalInfo::from(self.additional_info.get())
-	}
-	fn set_additional_info(&mut self, value: DirectoryAdditionalInfo) {
-		self.additional_info.set(value.into())
-	}
-	fn total_entries(&self) -> u32 {
-		self.total_entries.get()
-	}
-	fn set_total_entries(&mut self, value: u32) {
-		self.total_entries.set(value)
-	}
-	fn checksum(&self) -> u32 {
-		self.checksum.get()
-	}
-	fn set_checksum(&mut self, value: u32) {
-		self.checksum.set(value)
-	}
+    fn cookie(&self) -> [u8; 4] {
+        self.cookie
+    }
+    fn set_cookie(&mut self, value: [u8; 4]) {
+        self.cookie = value;
+    }
+    fn additional_info(&self) -> DirectoryAdditionalInfo {
+        DirectoryAdditionalInfo::from(self.additional_info.get())
+    }
+    fn set_additional_info(&mut self, value: DirectoryAdditionalInfo) {
+        self.additional_info.set(value.into())
+    }
+    fn total_entries(&self) -> u32 {
+        self.total_entries.get()
+    }
+    fn set_total_entries(&mut self, value: u32) {
+        self.total_entries.set(value)
+    }
+    fn checksum(&self) -> u32 {
+        self.checksum.get()
+    }
+    fn set_checksum(&mut self, value: u32) {
+        self.checksum.set(value)
+    }
 }
 
 impl Default for BhdDirectoryHeader {
-	fn default() -> Self {
-		Self {
-			cookie: *b"    ",   // invalid
-			checksum: 0.into(), // invalid
-			total_entries: 0.into(),
-			additional_info: 0xffff_ffff.into(), // invalid
-		}
-	}
+    fn default() -> Self {
+        Self {
+            cookie: *b"    ",   // invalid
+            checksum: 0.into(), // invalid
+            total_entries: 0.into(),
+            additional_info: 0xffff_ffff.into(), // invalid
+        }
+    }
 }
 
 impl core::fmt::Debug for BhdDirectoryHeader {
-	fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-		let checksum = self.checksum.get();
-		let total_entries = self.total_entries.get();
-		let additional_info = DirectoryAdditionalInfo::from(
-			self.additional_info.get(),
-		);
-		fmt.debug_struct("BhdDirectoryHeader")
-			.field("cookie", &self.cookie)
-			.field("checksum", &checksum)
-			.field("total_entries", &total_entries)
-			.field("additional_info", &additional_info)
-			.finish()
-	}
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let checksum = self.checksum.get();
+        let total_entries = self.total_entries.get();
+        let additional_info =
+            DirectoryAdditionalInfo::from(self.additional_info.get());
+        fmt.debug_struct("BhdDirectoryHeader")
+            .field("cookie", &self.cookie)
+            .field("checksum", &checksum)
+            .field("total_entries", &total_entries)
+            .field("additional_info", &additional_info)
+            .finish()
+    }
 }
 
 #[repr(u8)]
@@ -1162,22 +1137,22 @@ impl core::fmt::Debug for BhdDirectoryHeader {
 #[bits = 8]
 #[non_exhaustive]
 pub enum BhdDirectoryEntryType {
-	OemPublicKey = 0x05,
-	CryptographicSignature = 0x07,
-	Apcb = 0x60, // usually instances 0 (updatable) and 1 (eventlog)
-	Apob = 0x61,
-	Bios = 0x62,
-	ApobNvCopy = 0x63, // used during S3 resume
-	PmuFirmwareInstructions = 0x64,
-	PmuFirmwareData = 0x65,
-	MicrocodePatch = 0x66,
-	MceData = 0x67,
-	ApcbBackup = 0x68, // usually instances 0 (backup), 8 (updatable) and 9 (eventlog)
-	VgaInterpreter = 0x69,
-	Mp2FirmwareConfiguration = 0x6A,
-	CorebootVbootWorkbuffer = 0x6B, // main memory shared between PSP and x86
-	MpmConfiguration = 0x6C,
-	SecondLevelDirectory = 0x70, // also a BhdDirectory
+    OemPublicKey = 0x05,
+    CryptographicSignature = 0x07,
+    Apcb = 0x60, // usually instances 0 (updatable) and 1 (eventlog)
+    Apob = 0x61,
+    Bios = 0x62,
+    ApobNvCopy = 0x63, // used during S3 resume
+    PmuFirmwareInstructions = 0x64,
+    PmuFirmwareData = 0x65,
+    MicrocodePatch = 0x66,
+    MceData = 0x67,
+    ApcbBackup = 0x68, // usually instances 0 (backup), 8 (updatable) and 9 (eventlog)
+    VgaInterpreter = 0x69,
+    Mp2FirmwareConfiguration = 0x6A,
+    CorebootVbootWorkbuffer = 0x6B, // main memory shared between PSP and x86
+    MpmConfiguration = 0x6C,
+    SecondLevelDirectory = 0x70, // also a BhdDirectory
 }
 
 impl DummyErrorChecks for BhdDirectoryEntryType {}
@@ -1188,264 +1163,266 @@ impl DummyErrorChecks for BhdDirectoryEntryType {}
 #[bits = 8]
 #[non_exhaustive]
 pub enum BhdDirectoryEntryRegionType {
-	Normal = 0, // for X86: always
-	Ta1 = 1,
-	Ta2 = 2,
+    Normal = 0, // for X86: always
+    Ta1 = 1,
+    Ta2 = 2,
 }
 
 impl Default for BhdDirectoryEntryRegionType {
-	fn default() -> Self {
-		Self::Normal
-	}
+    fn default() -> Self {
+        Self::Normal
+    }
 }
 
 impl DummyErrorChecks for BhdDirectoryEntryRegionType {}
 
 make_bitfield_serde! {
-	#[bitfield(bits = 32)]
-	#[derive(Clone, Copy)]
-	#[repr(u32)]
-	pub struct BhdDirectoryEntryAttrs {
-		#[bits = 8]
-		#[allow(non_snake_case)]
-		pub type_: BhdDirectoryEntryType : pub get BhdDirectoryEntryType : pub set BhdDirectoryEntryType,
-		#[bits = 8]
-		pub region_type: BhdDirectoryEntryRegionType : pub get BhdDirectoryEntryRegionType : pub set BhdDirectoryEntryRegionType,
-		pub reset_image: bool : pub get bool : pub set bool,
-		pub copy_image: bool : pub get bool : pub set bool,
-		pub read_only: bool : pub get bool : pub set bool, // only useful for region_type > 0
-		pub compressed: bool : pub get bool : pub set bool,
-		pub instance: B4 : pub get u8 : pub set u8, // TODO: Shrink setter.
-		pub sub_program: B3 : pub get u8 : pub set u8, // function of AMD Family and Model; only useful for types PMU firmware and APCB binaries // TODO: Shrink setter.
-		pub rom_id: BhdDirectoryRomId : pub get BhdDirectoryRomId : pub set BhdDirectoryRomId,
-		#[skip]
-		__: B3,
-	}
+    #[bitfield(bits = 32)]
+    #[derive(Clone, Copy)]
+    #[repr(u32)]
+    pub struct BhdDirectoryEntryAttrs {
+        #[bits = 8]
+        #[allow(non_snake_case)]
+        pub type_: BhdDirectoryEntryType : pub get BhdDirectoryEntryType : pub set BhdDirectoryEntryType,
+        #[bits = 8]
+        pub region_type: BhdDirectoryEntryRegionType : pub get BhdDirectoryEntryRegionType : pub set BhdDirectoryEntryRegionType,
+        pub reset_image: bool : pub get bool : pub set bool,
+        pub copy_image: bool : pub get bool : pub set bool,
+        pub read_only: bool : pub get bool : pub set bool, // only useful for region_type > 0
+        pub compressed: bool : pub get bool : pub set bool,
+        pub instance: B4 : pub get u8 : pub set u8, // TODO: Shrink setter.
+        pub sub_program: B3 : pub get u8 : pub set u8, // function of AMD Family and Model; only useful for types PMU firmware and APCB binaries // TODO: Shrink setter.
+        pub rom_id: BhdDirectoryRomId : pub get BhdDirectoryRomId : pub set BhdDirectoryRomId,
+        #[skip]
+        __: B3,
+    }
 }
 make_accessors! {
-	#[derive(FromBytes, AsBytes, Unaligned, Clone, Copy)]
-	#[repr(C, packed)]
-	pub struct BhdDirectoryEntry {
-		attrs: LU32,
-		pub(crate) internal_size: LU32,   // 0xFFFF_FFFF for value entry
-		pub(crate) internal_source: LU64, // value (or nothing) iff size == 0; otherwise source_location; TODO: (iff directory.address_mode == 2) entry address mode (top 2 bits), or 0
-		pub(crate) internal_destination_location: LU64, // 0xffff_ffff_ffff_ffff: none
-	}
+    #[derive(FromBytes, AsBytes, Unaligned, Clone, Copy)]
+    #[repr(C, packed)]
+    pub struct BhdDirectoryEntry {
+        attrs: LU32,
+        pub(crate) internal_size: LU32,   // 0xFFFF_FFFF for value entry
+        pub(crate) internal_source: LU64, // value (or nothing) iff size == 0; otherwise source_location; TODO: (iff directory.address_mode == 2) entry address mode (top 2 bits), or 0
+        pub(crate) internal_destination_location: LU64, // 0xffff_ffff_ffff_ffff: none
+    }
 }
 
 impl DirectoryEntrySerde for BhdDirectoryEntry {
-	fn from_slice(source: &[u8]) -> Option<Self> {
-		let result = LayoutVerified::<_, Self>::new_unaligned(source)?;
-		Some(*result.into_ref())
-	}
-	fn copy_into_slice(&self, destination: &mut [u8]) {
-		destination.copy_from_slice(&self.as_bytes())
-	}
+    fn from_slice(source: &[u8]) -> Option<Self> {
+        let result = LayoutVerified::<_, Self>::new_unaligned(source)?;
+        Some(*result.into_ref())
+    }
+    fn copy_into_slice(&self, destination: &mut [u8]) {
+        destination.copy_from_slice(&self.as_bytes())
+    }
 }
 
 impl BhdDirectoryEntry {
-	const SIZE_VALUE_MARKER: u32 = 0xFFFF_FFFF;
-	const DESTINATION_NONE_MARKER: u64 = 0xffff_ffff_ffff_ffff;
-	pub fn type_or_err(&self) -> Result<BhdDirectoryEntryType> {
-		let attrs = BhdDirectoryEntryAttrs::from(self.attrs.get());
-		attrs.type__or_err().map_err(|_| Error::EntryTypeMismatch)
-	}
+    const SIZE_VALUE_MARKER: u32 = 0xFFFF_FFFF;
+    const DESTINATION_NONE_MARKER: u64 = 0xffff_ffff_ffff_ffff;
+    pub fn type_or_err(&self) -> Result<BhdDirectoryEntryType> {
+        let attrs = BhdDirectoryEntryAttrs::from(self.attrs.get());
+        attrs.type__or_err().map_err(|_| Error::EntryTypeMismatch)
+    }
 
-	pub fn destination_location(&self) -> Option<u64> {
-		let destination_location = self.internal_destination_location.get();
-		if destination_location == Self::DESTINATION_NONE_MARKER {
-			None
-		} else {
-			Some(destination_location)
-		}
-	}
-	pub fn with_type_(&mut self, value: BhdDirectoryEntryType) -> &mut Self {
-		let mut attrs = BhdDirectoryEntryAttrs::from(self.attrs.get());
-		attrs.set_type_(value);
-		self.attrs.set(u32::from_le_bytes(attrs.into_bytes()));
-		self
-	}
-	pub fn with_region_type(&mut self, value: BhdDirectoryEntryRegionType) -> &mut Self {
-		let mut attrs = BhdDirectoryEntryAttrs::from(self.attrs.get());
-		attrs.set_region_type(value);
-		self.attrs.set(u32::from_le_bytes(attrs.into_bytes()));
-		self
-	}
-	pub fn with_reset_image(&mut self, value: bool) -> &mut Self {
-		let mut attrs = BhdDirectoryEntryAttrs::from(self.attrs.get());
-		attrs.set_reset_image(value);
-		self.attrs.set(u32::from_le_bytes(attrs.into_bytes()));
-		self
-	}
-	pub fn with_copy_image(&mut self, value: bool) -> &mut Self {
-		let mut attrs = BhdDirectoryEntryAttrs::from(self.attrs.get());
-		attrs.set_copy_image(value);
-		self.attrs.set(u32::from_le_bytes(attrs.into_bytes()));
-		self
-	}
-	pub fn with_read_only(&mut self, value: bool) -> &mut Self {
-		let mut attrs = BhdDirectoryEntryAttrs::from(self.attrs.get());
-		attrs.set_read_only(value);
-		self.attrs.set(u32::from_le_bytes(attrs.into_bytes()));
-		self
-	}
-	pub fn with_compressed(&mut self, value: bool) -> &mut Self {
-		let mut attrs = BhdDirectoryEntryAttrs::from(self.attrs.get());
-		attrs.set_compressed(value);
-		self.attrs.set(u32::from_le_bytes(attrs.into_bytes()));
-		self
-	}
-	pub fn with_instance(&mut self, value: u8) -> &mut Self {
-		let mut attrs = BhdDirectoryEntryAttrs::from(self.attrs.get());
-		attrs.set_instance(value);
-		self.attrs.set(u32::from_le_bytes(attrs.into_bytes()));
-		self
-	}
-	pub fn with_sub_program(&mut self, value: u8) -> &mut Self {
-		let mut attrs = BhdDirectoryEntryAttrs::from(self.attrs.get());
-		attrs.set_sub_program(value);
-		self.attrs.set(u32::from_le_bytes(attrs.into_bytes()));
-		self
-	}
-	pub fn with_rom_id(&mut self, value: BhdDirectoryRomId) -> &mut Self {
-		let mut attrs = BhdDirectoryEntryAttrs::from(self.attrs.get());
-		attrs.set_rom_id(value);
-		self.attrs.set(u32::from_le_bytes(attrs.into_bytes()));
-		self
-	}
-	pub(crate) fn with_internal_destination_location(&mut self, value: u64) -> &mut Self {
-		self.internal_destination_location.set(value);
-		self
-	}
-	pub fn new() -> Self {
-		Self::default()
-	}
-	/// Note: Caller can modify other attributes afterwards (especially source--which he should modify).
-	pub fn new_payload(
-		directory_address_mode: AddressMode,
-		type_: BhdDirectoryEntryType,
-		size: Option<u32>,
-		source: Option<ValueOrLocation>,
-		destination_location: Option<u64>,
-	) -> Result<Self> {
-		let mut result = Self::new()
-			.with_type_(type_.into())
-			.with_internal_destination_location(
-				match destination_location {
-					None => Self::DESTINATION_NONE_MARKER,
-					Some(x) => {
-						if x == Self::DESTINATION_NONE_MARKER {
-							return Err(Error::EntryTypeMismatch);
-						}
-						x
-					}
-				}
-				.into(),
-			)
-			.build();
-		result.set_size(size);
-		if let Some(x) = source {
-			result.set_source(directory_address_mode, x)?;
-		} else {
-			result.set_size(None);
-		}
-		Ok(result)
-	}
+    pub fn destination_location(&self) -> Option<u64> {
+        let destination_location = self.internal_destination_location.get();
+        if destination_location == Self::DESTINATION_NONE_MARKER {
+            None
+        } else {
+            Some(destination_location)
+        }
+    }
+    pub fn with_type_(&mut self, value: BhdDirectoryEntryType) -> &mut Self {
+        let mut attrs = BhdDirectoryEntryAttrs::from(self.attrs.get());
+        attrs.set_type_(value);
+        self.attrs.set(u32::from_le_bytes(attrs.into_bytes()));
+        self
+    }
+    pub fn with_region_type(
+        &mut self,
+        value: BhdDirectoryEntryRegionType,
+    ) -> &mut Self {
+        let mut attrs = BhdDirectoryEntryAttrs::from(self.attrs.get());
+        attrs.set_region_type(value);
+        self.attrs.set(u32::from_le_bytes(attrs.into_bytes()));
+        self
+    }
+    pub fn with_reset_image(&mut self, value: bool) -> &mut Self {
+        let mut attrs = BhdDirectoryEntryAttrs::from(self.attrs.get());
+        attrs.set_reset_image(value);
+        self.attrs.set(u32::from_le_bytes(attrs.into_bytes()));
+        self
+    }
+    pub fn with_copy_image(&mut self, value: bool) -> &mut Self {
+        let mut attrs = BhdDirectoryEntryAttrs::from(self.attrs.get());
+        attrs.set_copy_image(value);
+        self.attrs.set(u32::from_le_bytes(attrs.into_bytes()));
+        self
+    }
+    pub fn with_read_only(&mut self, value: bool) -> &mut Self {
+        let mut attrs = BhdDirectoryEntryAttrs::from(self.attrs.get());
+        attrs.set_read_only(value);
+        self.attrs.set(u32::from_le_bytes(attrs.into_bytes()));
+        self
+    }
+    pub fn with_compressed(&mut self, value: bool) -> &mut Self {
+        let mut attrs = BhdDirectoryEntryAttrs::from(self.attrs.get());
+        attrs.set_compressed(value);
+        self.attrs.set(u32::from_le_bytes(attrs.into_bytes()));
+        self
+    }
+    pub fn with_instance(&mut self, value: u8) -> &mut Self {
+        let mut attrs = BhdDirectoryEntryAttrs::from(self.attrs.get());
+        attrs.set_instance(value);
+        self.attrs.set(u32::from_le_bytes(attrs.into_bytes()));
+        self
+    }
+    pub fn with_sub_program(&mut self, value: u8) -> &mut Self {
+        let mut attrs = BhdDirectoryEntryAttrs::from(self.attrs.get());
+        attrs.set_sub_program(value);
+        self.attrs.set(u32::from_le_bytes(attrs.into_bytes()));
+        self
+    }
+    pub fn with_rom_id(&mut self, value: BhdDirectoryRomId) -> &mut Self {
+        let mut attrs = BhdDirectoryEntryAttrs::from(self.attrs.get());
+        attrs.set_rom_id(value);
+        self.attrs.set(u32::from_le_bytes(attrs.into_bytes()));
+        self
+    }
+    pub(crate) fn with_internal_destination_location(
+        &mut self,
+        value: u64,
+    ) -> &mut Self {
+        self.internal_destination_location.set(value);
+        self
+    }
+    pub fn new() -> Self {
+        Self::default()
+    }
+    /// Note: Caller can modify other attributes afterwards (especially source--which he should modify).
+    pub fn new_payload(
+        directory_address_mode: AddressMode,
+        type_: BhdDirectoryEntryType,
+        size: Option<u32>,
+        source: Option<ValueOrLocation>,
+        destination_location: Option<u64>,
+    ) -> Result<Self> {
+        let mut result = Self::new()
+            .with_type_(type_.into())
+            .with_internal_destination_location(
+                match destination_location {
+                    None => Self::DESTINATION_NONE_MARKER,
+                    Some(x) => {
+                        if x == Self::DESTINATION_NONE_MARKER {
+                            return Err(Error::EntryTypeMismatch);
+                        }
+                        x
+                    }
+                }
+                .into(),
+            )
+            .build();
+        result.set_size(size);
+        if let Some(x) = source {
+            result.set_source(directory_address_mode, x)?;
+        } else {
+            result.set_size(None);
+        }
+        Ok(result)
+    }
 }
 
 // TODO: Remove.
 impl Default for BhdDirectoryEntry {
-	fn default() -> Self {
-		Self {
-			attrs: 0.into(),
-			internal_size: 0.into(),
-			internal_source: 0.into(),
-			internal_destination_location: Self::DESTINATION_NONE_MARKER.into(),
-		}
-	}
+    fn default() -> Self {
+        Self {
+            attrs: 0.into(),
+            internal_size: 0.into(),
+            internal_source: 0.into(),
+            internal_destination_location: Self::DESTINATION_NONE_MARKER.into(),
+        }
+    }
 }
 
 impl DirectoryEntry for BhdDirectoryEntry {
-	fn source(
-		&self,
-		directory_address_mode: AddressMode,
-	) -> Result<ValueOrLocation> {
-		let size = self.internal_size.get();
-		let source = self.internal_source.get();
-		if size == Self::SIZE_VALUE_MARKER {
-			Ok(ValueOrLocation::Value(source))
-		} else {
-			let source = self.internal_source.get();
-			ValueOrLocation::new_from_raw_location(
-				directory_address_mode,
-				source,
-			)
-		}
-	}
-	fn set_source(
-		&mut self,
-		directory_address_mode: AddressMode,
-		value: ValueOrLocation,
-	) -> Result<()> {
-		match value {
-			ValueOrLocation::Value(v) => {
-				if self.internal_size.get() ==
-					Self::SIZE_VALUE_MARKER
-				{
-					self.internal_source.set(v);
-					Ok(())
-				} else {
-					Err(Error::EntryTypeMismatch)
-				}
-			}
-			x => {
-				let v = x.try_into_raw_location(
-					directory_address_mode,
-				)?;
-				self.internal_source.set(v);
-				Ok(())
-			}
-		}
-	}
-	fn size(&self) -> Option<u32> {
-		let size = self.internal_size.get();
-		if size == Self::SIZE_VALUE_MARKER {
-			None
-		} else {
-			Some(size)
-		}
-	}
-	fn set_size(&mut self, value: Option<u32>) {
-		self.internal_size.set(match value {
-			None => Self::SIZE_VALUE_MARKER,
-			Some(x) => {
-				assert!(x != Self::SIZE_VALUE_MARKER);
-				x
-			}
-		})
-	}
+    fn source(
+        &self,
+        directory_address_mode: AddressMode,
+    ) -> Result<ValueOrLocation> {
+        let size = self.internal_size.get();
+        let source = self.internal_source.get();
+        if size == Self::SIZE_VALUE_MARKER {
+            Ok(ValueOrLocation::Value(source))
+        } else {
+            let source = self.internal_source.get();
+            ValueOrLocation::new_from_raw_location(
+                directory_address_mode,
+                source,
+            )
+        }
+    }
+    fn set_source(
+        &mut self,
+        directory_address_mode: AddressMode,
+        value: ValueOrLocation,
+    ) -> Result<()> {
+        match value {
+            ValueOrLocation::Value(v) => {
+                if self.internal_size.get() == Self::SIZE_VALUE_MARKER {
+                    self.internal_source.set(v);
+                    Ok(())
+                } else {
+                    Err(Error::EntryTypeMismatch)
+                }
+            }
+            x => {
+                let v = x.try_into_raw_location(directory_address_mode)?;
+                self.internal_source.set(v);
+                Ok(())
+            }
+        }
+    }
+    fn size(&self) -> Option<u32> {
+        let size = self.internal_size.get();
+        if size == Self::SIZE_VALUE_MARKER {
+            None
+        } else {
+            Some(size)
+        }
+    }
+    fn set_size(&mut self, value: Option<u32>) {
+        self.internal_size.set(match value {
+            None => Self::SIZE_VALUE_MARKER,
+            Some(x) => {
+                assert!(x != Self::SIZE_VALUE_MARKER);
+                x
+            }
+        })
+    }
 }
 
 impl core::fmt::Debug for BhdDirectoryEntry {
-	fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-		// DirectoryRelativeOffset (WEAK_ADDRESS_MODE) is the only one that's always overridable.
-		let source = self.source(WEAK_ADDRESS_MODE);
-		let destination_location = self.destination_location();
-		let size = self.size();
-		let attrs = BhdDirectoryEntryAttrs::from(self.attrs.get());
-		fmt.debug_struct("BhdDirectoryEntry")
-			.field("type_", &attrs.type__or_err())
-			.field("region_type", &attrs.region_type_or_err())
-			.field("reset_image", &attrs.reset_image_or_err())
-			.field("copy_image", &attrs.copy_image_or_err())
-			.field("read_only", &attrs.read_only_or_err())
-			.field("compressed", &attrs.compressed_or_err())
-			.field("instance", &attrs.instance_or_err())
-			.field("size", &size)
-			.field("source", &source)
-			.field("destination_location", &destination_location)
-			.finish()
-	}
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // DirectoryRelativeOffset (WEAK_ADDRESS_MODE) is the only one that's always overridable.
+        let source = self.source(WEAK_ADDRESS_MODE);
+        let destination_location = self.destination_location();
+        let size = self.size();
+        let attrs = BhdDirectoryEntryAttrs::from(self.attrs.get());
+        fmt.debug_struct("BhdDirectoryEntry")
+            .field("type_", &attrs.type__or_err())
+            .field("region_type", &attrs.region_type_or_err())
+            .field("reset_image", &attrs.reset_image_or_err())
+            .field("copy_image", &attrs.copy_image_or_err())
+            .field("read_only", &attrs.read_only_or_err())
+            .field("compressed", &attrs.compressed_or_err())
+            .field("instance", &attrs.instance_or_err())
+            .field("size", &size)
+            .field("source", &source)
+            .field("destination_location", &destination_location)
+            .finish()
+    }
 }
 
 #[repr(u32)]
@@ -1454,69 +1431,69 @@ impl core::fmt::Debug for BhdDirectoryEntry {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub enum ComboDirectoryLookupMode {
-	BruteForce = 0,
-	MatchId = 1,
+    BruteForce = 0,
+    MatchId = 1,
 }
 
 make_accessors! {
-	#[derive(FromBytes, AsBytes, Unaligned, Clone, Copy, Debug)]
-	#[repr(C, packed)]
-	pub struct ComboDirectoryHeader {
-		pub(crate) cookie: [u8; 4], // b"2PSP" or b"2BHD"
-		pub(crate) checksum: LU32, // 32-bit CRC value of header below this field and including all entries
-		pub(crate) total_entries: LU32,
-		pub(crate) lookup_mode: LU32 : pub get ComboDirectoryLookupMode : pub set ComboDirectoryLookupMode,
-		_reserved: [u8; 16], // 0
-	}
+    #[derive(FromBytes, AsBytes, Unaligned, Clone, Copy, Debug)]
+    #[repr(C, packed)]
+    pub struct ComboDirectoryHeader {
+        pub(crate) cookie: [u8; 4], // b"2PSP" or b"2BHD"
+        pub(crate) checksum: LU32, // 32-bit CRC value of header below this field and including all entries
+        pub(crate) total_entries: LU32,
+        pub(crate) lookup_mode: LU32 : pub get ComboDirectoryLookupMode : pub set ComboDirectoryLookupMode,
+        _reserved: [u8; 16], // 0
+    }
 }
 
 impl Default for ComboDirectoryHeader {
-	fn default() -> Self {
-		Self {
-			cookie: *b"FIXM",
-			checksum: 0.into(),
-			lookup_mode: 0.into(),
-			total_entries: 0.into(),
-			_reserved: [0; 16],
-		}
-	}
+    fn default() -> Self {
+        Self {
+            cookie: *b"FIXM",
+            checksum: 0.into(),
+            lookup_mode: 0.into(),
+            total_entries: 0.into(),
+            _reserved: [0; 16],
+        }
+    }
 }
 
 impl DirectoryHeader for ComboDirectoryHeader {
-	fn cookie(&self) -> [u8; 4] {
-		self.cookie
-	}
-	fn set_cookie(&mut self, value: [u8; 4]) {
-		self.cookie = value;
-	}
-	fn additional_info(&self) -> DirectoryAdditionalInfo {
-		DirectoryAdditionalInfo::from(0)
-	}
-	fn set_additional_info(&mut self, _value: DirectoryAdditionalInfo) {}
-	fn total_entries(&self) -> u32 {
-		self.total_entries.get()
-	}
-	fn set_total_entries(&mut self, value: u32) {
-		self.total_entries.set(value)
-	}
-	fn checksum(&self) -> u32 {
-		self.checksum.get()
-	}
-	fn set_checksum(&mut self, value: u32) {
-		self.checksum.set(value)
-	}
+    fn cookie(&self) -> [u8; 4] {
+        self.cookie
+    }
+    fn set_cookie(&mut self, value: [u8; 4]) {
+        self.cookie = value;
+    }
+    fn additional_info(&self) -> DirectoryAdditionalInfo {
+        DirectoryAdditionalInfo::from(0)
+    }
+    fn set_additional_info(&mut self, _value: DirectoryAdditionalInfo) {}
+    fn total_entries(&self) -> u32 {
+        self.total_entries.get()
+    }
+    fn set_total_entries(&mut self, value: u32) {
+        self.total_entries.set(value)
+    }
+    fn checksum(&self) -> u32 {
+        self.checksum.get()
+    }
+    fn set_checksum(&mut self, value: u32) {
+        self.checksum.set(value)
+    }
 }
 
 impl ComboDirectoryHeader {
-	pub fn new(cookie: [u8; 4]) -> Result<Self> {
-		if cookie == *b"2PSP" || cookie == *b"2BHD" {
-			let mut result = Self::default();
-			result.cookie = cookie;
-			Ok(result)
-		} else {
-			Err(Error::DirectoryTypeMismatch)
-		}
-	}
+    pub fn new(cookie: [u8; 4]) -> Result<Self> {
+        if cookie == *b"2PSP" || cookie == *b"2BHD" {
+            let mut result = Self::default();
+            result.cookie = cookie;
+            Ok(result)
+        } else {
+            Err(Error::DirectoryTypeMismatch)
+        }
+    }
 }
 
 //#[repr(u8)]
@@ -1525,179 +1502,166 @@ impl ComboDirectoryHeader {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub enum ComboDirectoryEntryFilter {
-	PspId(u32),        // = 0,
-	ChipFamilyId(u32), // = 1,
+    PspId(u32),        // = 0,
+    ChipFamilyId(u32), // = 1,
 }
 
 #[derive(Clone, Copy, FromBytes, AsBytes, Unaligned)]
 #[repr(C, packed)]
 pub struct ComboDirectoryEntry {
-	pub(crate) internal_key: LU32, // 0-PSP ID; 1-chip family ID
-	pub(crate) internal_value: LU32,
-	pub(crate) internal_source: LU64, // that's the (Psp|Bhd) directory entry location. Note: If 32 bit high nibble is set, then that's a physical address
+    pub(crate) internal_key: LU32, // 0-PSP ID; 1-chip family ID
+    pub(crate) internal_value: LU32,
+    pub(crate) internal_source: LU64, // that's the (Psp|Bhd) directory entry location. Note: If 32 bit high nibble is set, then that's a physical address
 }
 
 impl DirectoryEntrySerde for ComboDirectoryEntry {
-	fn from_slice(source: &[u8]) -> Option<Self> {
-		let result = LayoutVerified::<_, Self>::new_unaligned(source)?;
-		Some(*result.into_ref())
-	}
-	fn copy_into_slice(&self, destination: &mut [u8]) {
-		destination.copy_from_slice(&self.as_bytes())
-	}
+    fn from_slice(source: &[u8]) -> Option<Self> {
+        let result = LayoutVerified::<_, Self>::new_unaligned(source)?;
+        Some(*result.into_ref())
+    }
+    fn copy_into_slice(&self, destination: &mut [u8]) {
+        destination.copy_from_slice(&self.as_bytes())
+    }
 }
 
 impl core::fmt::Debug for ComboDirectoryEntry {
-	fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-		// DirectoryRelativeOffset (WEAK_ADDRESS_MODE) is the only one that's always overridable.
-		let internal_key = self.internal_key;
-		let internal_value = self.internal_value;
-		let source = self.source(WEAK_ADDRESS_MODE);
-		fmt.debug_struct("ComboDirectoryEntry")
-			.field("key", &internal_key)
-			.field("value", &internal_value)
-			.field("source", &source)
-			.finish()
-	}
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // DirectoryRelativeOffset (WEAK_ADDRESS_MODE) is the only one that's always overridable.
+        let internal_key = self.internal_key;
+        let internal_value = self.internal_value;
+        let source = self.source(WEAK_ADDRESS_MODE);
+        fmt.debug_struct("ComboDirectoryEntry")
+            .field("key", &internal_key)
+            .field("value", &internal_value)
+            .field("source", &source)
+            .finish()
+    }
 }
 
 // TODO: Remove.
 impl Default for ComboDirectoryEntry {
-	fn default() -> Self {
-		Self {
-			internal_key: 0.into(),
-			internal_value: 0.into(),
-			internal_source: 0.into(),
-		}
-	}
+    fn default() -> Self {
+        Self {
+            internal_key: 0.into(),
+            internal_value: 0.into(),
+            internal_source: 0.into(),
+        }
+    }
 }
 
 impl DirectoryEntry for ComboDirectoryEntry {
-	// XXX
-	fn source(
-		&self,
-		directory_address_mode: AddressMode,
-	) -> Result<ValueOrLocation> {
-		let source = self.internal_source.get();
-		ValueOrLocation::new_from_raw_location(
-			directory_address_mode,
-			source,
-		)
-	}
-	fn set_source(
-		&mut self,
-		directory_address_mode: AddressMode,
-		value: ValueOrLocation,
-	) -> Result<()> {
-		match value {
-			ValueOrLocation::Value(_) => {
-				Err(Error::EntryTypeMismatch)
-			}
-			x => {
-				let v = x.try_into_raw_location(
-					directory_address_mode,
-				)?;
-				self.internal_source = v.into();
-				Ok(())
-			}
-		}
-	}
-	fn size(&self) -> Option<u32> {
-		None
-	}
-	fn set_size(&mut self, value: Option<u32>) {
-		assert!(false);
-	}
+    // XXX
+    fn source(
+        &self,
+        directory_address_mode: AddressMode,
+    ) -> Result<ValueOrLocation> {
+        let source = self.internal_source.get();
+        ValueOrLocation::new_from_raw_location(directory_address_mode, source)
+    }
+    fn set_source(
+        &mut self,
+        directory_address_mode: AddressMode,
+        value: ValueOrLocation,
+    ) -> Result<()> {
+        match value {
+            ValueOrLocation::Value(_) => Err(Error::EntryTypeMismatch),
+            x => {
+                let v = x.try_into_raw_location(directory_address_mode)?;
+                self.internal_source = v.into();
+                Ok(())
+            }
+        }
+    }
+    fn size(&self) -> Option<u32> {
+        None
+    }
+    fn set_size(&mut self, value: Option<u32>) {
+        assert!(false);
+    }
 }
 
 impl ComboDirectoryEntry {
-	pub fn filter(&self) -> Result<ComboDirectoryEntryFilter> {
-		let key = self.internal_key.get();
-		let value = self.internal_value.get();
-		match key {
-			0 => Ok(ComboDirectoryEntryFilter::PspId(value)),
-			1 => Ok(ComboDirectoryEntryFilter::ChipFamilyId(value)),
-			_ => Err(Error::DirectoryTypeMismatch),
-		}
-	}
-	pub fn set_filter(&mut self, value: ComboDirectoryEntryFilter) {
-		match value {
-			ComboDirectoryEntryFilter::PspId(value) => {
-				self.internal_key.set(0);
-				self.internal_value.set(value.into());
-			}
-			ComboDirectoryEntryFilter::ChipFamilyId(value) => {
-				self.internal_key.set(0);
-				self.internal_value.set(value.into());
-			}
-		}
-	}
-	pub fn new() -> Self {
-		Self::default()
-	}
+    pub fn filter(&self) -> Result<ComboDirectoryEntryFilter> {
+        let key = self.internal_key.get();
+        let value = self.internal_value.get();
+        match key {
+            0 => Ok(ComboDirectoryEntryFilter::PspId(value)),
+            1 => Ok(ComboDirectoryEntryFilter::ChipFamilyId(value)),
+            _ => Err(Error::DirectoryTypeMismatch),
+        }
+    }
+    pub fn set_filter(&mut self, value: ComboDirectoryEntryFilter) {
+        match value {
+            ComboDirectoryEntryFilter::PspId(value) => {
+                self.internal_key.set(0);
+                self.internal_value.set(value.into());
+            }
+            ComboDirectoryEntryFilter::ChipFamilyId(value) => {
+                self.internal_key.set(0);
+                self.internal_value.set(value.into());
+            }
+        }
+    }
+    pub fn new() -> Self {
+        Self::default()
+    }
 }
 
 #[cfg(test)]
 mod tests {
-	use super::*;
-	use core::mem::size_of;
+    use super::*;
+    use core::mem::size_of;
 
-	#[test]
-	fn test_struct_sizes() {
-		assert!(size_of::<EfhBulldozerSpiMode>() == 3);
-		assert!(size_of::<EfhNaplesSpiMode>() == 3);
-		assert!(size_of::<EfhRomeSpiMode>() == 3);
-		assert!(size_of::<Efh>() < 0x100);
-		assert!(size_of::<PspDirectoryHeader>() == 16);
-		assert!(size_of::<PspDirectoryEntry>() == 16);
-		assert!(size_of::<BhdDirectoryHeader>() == 16);
-		assert!(size_of::<BhdDirectoryEntry>() == 24);
-		assert!(size_of::<ComboDirectoryHeader>() == 32);
-		assert!(size_of::<ComboDirectoryEntry>() == 16);
-	}
+    #[test]
+    fn test_struct_sizes() {
+        assert!(size_of::<EfhBulldozerSpiMode>() == 3);
+        assert!(size_of::<EfhNaplesSpiMode>() == 3);
+        assert!(size_of::<EfhRomeSpiMode>() == 3);
+        assert!(size_of::<Efh>() < 0x100);
+        assert!(size_of::<PspDirectoryHeader>() == 16);
+        assert!(size_of::<PspDirectoryEntry>() == 16);
+        assert!(size_of::<BhdDirectoryHeader>() == 16);
+        assert!(size_of::<BhdDirectoryEntry>() == 24);
+        assert!(size_of::<ComboDirectoryHeader>() == 32);
+        assert!(size_of::<ComboDirectoryEntry>() == 16);
+    }
 
-	#[test]
-	fn test_directory_additional_info() {
-		let info = DirectoryAdditionalInfo::new()
-			.with_spi_block_size_checked(
-				DirectoryAdditionalInfo::try_into_unit(
-					0x1_0000,
-				)
-				.unwrap(),
-			)
-			.unwrap();
-		assert_eq!(u32::from(info), 0);
+    #[test]
+    fn test_directory_additional_info() {
+        let info = DirectoryAdditionalInfo::new()
+            .with_spi_block_size_checked(
+                DirectoryAdditionalInfo::try_into_unit(0x1_0000).unwrap(),
+            )
+            .unwrap();
+        assert_eq!(u32::from(info), 0);
 
-		let info = DirectoryAdditionalInfo::new()
-			.with_spi_block_size_checked(
-				DirectoryAdditionalInfo::try_into_unit(0x1000)
-					.unwrap(),
-			)
-			.unwrap();
-		assert_eq!(u32::from(info), 1 << 10);
+        let info = DirectoryAdditionalInfo::new()
+            .with_spi_block_size_checked(
+                DirectoryAdditionalInfo::try_into_unit(0x1000).unwrap(),
+            )
+            .unwrap();
+        assert_eq!(u32::from(info), 1 << 10);
 
-		let info = DirectoryAdditionalInfo::new()
-			.with_spi_block_size_checked(
-				DirectoryAdditionalInfo::try_into_unit(0x2000)
-					.unwrap(),
-			)
-			.unwrap();
-		assert_eq!(u32::from(info), 2 << 10);
+        let info = DirectoryAdditionalInfo::new()
+            .with_spi_block_size_checked(
+                DirectoryAdditionalInfo::try_into_unit(0x2000).unwrap(),
+            )
+            .unwrap();
+        assert_eq!(u32::from(info), 2 << 10);
 
-		let info = DirectoryAdditionalInfo::new()
-			.with_spi_block_size_checked(
-				DirectoryAdditionalInfo::try_into_unit(0xf000)
-					.unwrap(),
-			)
-			.unwrap();
-		assert_eq!(u32::from(info), 0xf << 10);
-	}
+        let info = DirectoryAdditionalInfo::new()
+            .with_spi_block_size_checked(
+                DirectoryAdditionalInfo::try_into_unit(0xf000).unwrap(),
+            )
+            .unwrap();
+        assert_eq!(u32::from(info), 0xf << 10);
+    }
 
-	#[test]
-	#[should_panic]
-	fn test_directory_additional_info_invalid() {
-		let _info = DirectoryAdditionalInfo::new()
-			.with_spi_block_size_checked(0)
-			.unwrap();
-	}
+    #[test]
+    #[should_panic]
+    fn test_directory_additional_info_invalid() {
+        let _info = DirectoryAdditionalInfo::new()
+            .with_spi_block_size_checked(0)
+            .unwrap();
+    }
 }

--- a/src/serializers.rs
+++ b/src/serializers.rs
@@ -49,58 +49,58 @@ macro_rules! make_serde{($StructName:ident, $SerdeStructName:ident, [$($field_na
 )}
 
 make_serde!(
-	EfhBulldozerSpiMode,
-	SerdeEfhBulldozerSpiMode,
-	[read_mode, fast_speed_new]
+    EfhBulldozerSpiMode,
+    SerdeEfhBulldozerSpiMode,
+    [read_mode, fast_speed_new]
 );
 make_serde!(
-	EfhNaplesSpiMode,
-	SerdeEfhNaplesSpiMode,
-	[read_mode, fast_speed_new, micron_mode]
+    EfhNaplesSpiMode,
+    SerdeEfhNaplesSpiMode,
+    [read_mode, fast_speed_new, micron_mode]
 );
 make_serde!(
-	EfhRomeSpiMode,
-	SerdeEfhRomeSpiMode,
-	[read_mode, fast_speed_new, micron_mode]
+    EfhRomeSpiMode,
+    SerdeEfhRomeSpiMode,
+    [read_mode, fast_speed_new, micron_mode]
 );
 make_serde!(
-	Efh,
-	SerdeEfh,
-	[
-		signature,
-		bhd_directory_table_milan,
-		xhci_fw_location,
-		gbe_fw_location,
-		imc_fw_location,
-		low_power_promontory_firmware_location,
-		promontory_firmware_location,
-		psp_directory_table_location_naples,
-		psp_directory_table_location_zen,
-		spi_mode_bulldozer,
-		spi_mode_zen_naples,
-		spi_mode_zen_rome
-	]
+    Efh,
+    SerdeEfh,
+    [
+        signature,
+        bhd_directory_table_milan,
+        xhci_fw_location,
+        gbe_fw_location,
+        imc_fw_location,
+        low_power_promontory_firmware_location,
+        promontory_firmware_location,
+        psp_directory_table_location_naples,
+        psp_directory_table_location_zen,
+        spi_mode_bulldozer,
+        spi_mode_zen_naples,
+        spi_mode_zen_rome
+    ]
 );
 
 make_serde!(
-	DirectoryAdditionalInfo,
-	SerdeDirectoryAdditionalInfo,
-	[base_address, address_mode, max_size]
+    DirectoryAdditionalInfo,
+    SerdeDirectoryAdditionalInfo,
+    [base_address, address_mode, max_size]
 );
 make_serde!(
-	PspSoftFuseChain,
-	SerdePspSoftFuseChain,
-	[
-		secure_debug_unlock,
-		early_secure_debug_unlock,
-		unlock_token_in_nvram,
-		force_security_policy_loading_even_if_insecure,
-		load_diagnostic_bootloader,
-		disable_psp_debug_prints,
-		spi_decoding,
-		postcode_decoding,
-		skip_mp2_firmware_loading,
-		postcode_output_control_1byte,
-		force_recovery_booting
-	]
+    PspSoftFuseChain,
+    SerdePspSoftFuseChain,
+    [
+        secure_debug_unlock,
+        early_secure_debug_unlock,
+        unlock_token_in_nvram,
+        force_security_policy_loading_even_if_insecure,
+        load_diagnostic_bootloader,
+        disable_psp_debug_prints,
+        spi_decoding,
+        postcode_decoding,
+        skip_mp2_firmware_loading,
+        postcode_output_control_1byte,
+        force_recovery_booting
+    ]
 );

--- a/src/struct_accessors.rs
+++ b/src/struct_accessors.rs
@@ -11,123 +11,123 @@ use zerocopy::{AsBytes, FromBytes, U16, U32, U64};
 //}
 
 pub(crate) trait Getter<T> {
-	fn get1(self) -> T;
+    fn get1(self) -> T;
 }
 impl Getter<u64> for U64<LittleEndian> {
-	fn get1(self) -> u64 {
-		self.get()
-	}
+    fn get1(self) -> u64 {
+        self.get()
+    }
 }
 impl Getter<u32> for U32<LittleEndian> {
-	fn get1(self) -> u32 {
-		self.get()
-	}
+    fn get1(self) -> u32 {
+        self.get()
+    }
 }
 impl Getter<u16> for U16<LittleEndian> {
-	fn get1(self) -> u16 {
-		self.get()
-	}
+    fn get1(self) -> u16 {
+        self.get()
+    }
 }
 impl Getter<u8> for u8 {
-	fn get1(self) -> u8 {
-		self
-	}
+    fn get1(self) -> u8 {
+        self
+    }
 }
 impl<'a> Getter<&'a [u8]> for &'a [u8] {
-	fn get1(self) -> &'a [u8] {
-		self
-	}
+    fn get1(self) -> &'a [u8] {
+        self
+    }
 }
 impl<T: FromPrimitive> Getter<Result<T>> for u8 {
-	fn get1(self) -> Result<T> {
-		T::from_u8(self).ok_or(Error::EntryTypeMismatch)
-	}
+    fn get1(self) -> Result<T> {
+        T::from_u8(self).ok_or(Error::EntryTypeMismatch)
+    }
 }
 impl<T: FromPrimitive> Getter<Result<T>> for U32<LittleEndian> {
-	fn get1(self) -> Result<T> {
-		T::from_u32(self.get()).ok_or(Error::EntryTypeMismatch)
-	}
+    fn get1(self) -> Result<T> {
+        T::from_u32(self.get()).ok_or(Error::EntryTypeMismatch)
+    }
 }
 // For Token
 impl<T: FromPrimitive> Getter<Result<T>> for u32 {
-	fn get1(self) -> Result<T> {
-		T::from_u32(self).ok_or(Error::EntryTypeMismatch)
-	}
+    fn get1(self) -> Result<T> {
+        T::from_u32(self).ok_or(Error::EntryTypeMismatch)
+    }
 }
 #[derive(Debug, PartialEq, FromBytes, AsBytes, Clone, Copy)]
 #[repr(C, packed)]
 pub(crate) struct BU8(pub(crate) u8);
 impl Getter<Result<bool>> for BU8 {
-	fn get1(self) -> Result<bool> {
-		match self.0 {
-			0 => Ok(false),
-			1 => Ok(true),
-			_ => Err(Error::EntryTypeMismatch),
-		}
-	}
+    fn get1(self) -> Result<bool> {
+        match self.0 {
+            0 => Ok(false),
+            1 => Ok(true),
+            _ => Err(Error::EntryTypeMismatch),
+        }
+    }
 }
 
 impl From<bool> for BU8 {
-	fn from(value: bool) -> Self {
-		match value {
-			true => Self(1),
-			false => Self(0),
-		}
-	}
+    fn from(value: bool) -> Self {
+        match value {
+            true => Self(1),
+            false => Self(0),
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, FromBytes, AsBytes, Clone, Copy)]
 #[repr(C, packed)]
 pub(crate) struct BLU16(pub(crate) U16<LittleEndian>);
 impl Getter<Result<bool>> for BLU16 {
-	fn get1(self) -> Result<bool> {
-		match self.0.get() {
-			0 => Ok(false),
-			1 => Ok(true),
-			_ => Err(Error::EntryTypeMismatch),
-		}
-	}
+    fn get1(self) -> Result<bool> {
+        match self.0.get() {
+            0 => Ok(false),
+            1 => Ok(true),
+            _ => Err(Error::EntryTypeMismatch),
+        }
+    }
 }
 
 pub(crate) trait Setter<T> {
-	fn set1(&mut self, value: T);
+    fn set1(&mut self, value: T);
 }
 impl<T: ToPrimitive> Setter<T> for U64<LittleEndian> {
-	fn set1(&mut self, value: T) {
-		self.set(value.to_u64().unwrap())
-	}
+    fn set1(&mut self, value: T) {
+        self.set(value.to_u64().unwrap())
+    }
 }
 impl<T: ToPrimitive> Setter<T> for U32<LittleEndian> {
-	fn set1(&mut self, value: T) {
-		self.set(value.to_u32().unwrap())
-	}
+    fn set1(&mut self, value: T) {
+        self.set(value.to_u32().unwrap())
+    }
 }
 impl<T: ToPrimitive> Setter<T> for U16<LittleEndian> {
-	// maybe never happens
-	fn set1(&mut self, value: T) {
-		self.set(value.to_u16().unwrap())
-	}
+    // maybe never happens
+    fn set1(&mut self, value: T) {
+        self.set(value.to_u16().unwrap())
+    }
 }
 impl<T: ToPrimitive> Setter<T> for u8 {
-	fn set1(&mut self, value: T) {
-		*self = value.to_u8().unwrap()
-	}
+    fn set1(&mut self, value: T) {
+        *self = value.to_u8().unwrap()
+    }
 }
 impl Setter<bool> for BU8 {
-	fn set1(&mut self, value: bool) {
-		*self = BU8(match value {
-			false => 0,
-			true => 1,
-		})
-	}
+    fn set1(&mut self, value: bool) {
+        *self = BU8(match value {
+            false => 0,
+            true => 1,
+        })
+    }
 }
 impl Setter<bool> for BLU16 {
-	fn set1(&mut self, value: bool) {
-		*self = Self(match value {
-			false => 0.into(),
-			true => 1.into(),
-		})
-	}
+    fn set1(&mut self, value: bool) {
+        *self = Self(match value {
+            false => 0.into(),
+            true => 1.into(),
+        })
+    }
 }
 
 /// Since primitive types are not a Result, this just wraps them into a Result.
@@ -135,12 +135,12 @@ impl Setter<bool> for BLU16 {
 /// the getters return Result--but they have to be able to call map_err
 /// on it in case these DO return Result.
 pub(crate) trait DummyErrorChecks: Sized {
-	fn map_err<F, O>(self, _op: O) -> core::result::Result<Self, F>
-	where
-		O: Fn(Self) -> F,
-	{
-		Ok(self)
-	}
+    fn map_err<F, O>(self, _op: O) -> core::result::Result<Self, F>
+    where
+        O: Fn(Self) -> F,
+    {
+        Ok(self)
+    }
 }
 
 impl DummyErrorChecks for u16 {}

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,25 +1,25 @@
 #[derive(Debug)]
 pub enum Error {
-	Io(amd_flash::Error),
-	EfsHeaderNotFound,
-	EfsRangeCheck,
-	PspDirectoryHeaderNotFound,
-	BhdDirectoryHeaderNotFound,
-	DirectoryRangeCheck,
-	DirectoryPayloadRangeCheck,
-	Marshal,
-	Overlap,
-	Duplicate,
-	Misaligned,
-	EntryTypeMismatch,
-	EntryNotFound,
-	DirectoryTypeMismatch,
+    Io(amd_flash::Error),
+    EfsHeaderNotFound,
+    EfsRangeCheck,
+    PspDirectoryHeaderNotFound,
+    BhdDirectoryHeaderNotFound,
+    DirectoryRangeCheck,
+    DirectoryPayloadRangeCheck,
+    Marshal,
+    Overlap,
+    Duplicate,
+    Misaligned,
+    EntryTypeMismatch,
+    EntryNotFound,
+    DirectoryTypeMismatch,
 }
 
 pub type Result<Q> = core::result::Result<Q, Error>;
 
 impl From<amd_flash::Error> for Error {
-	fn from(error: amd_flash::Error) -> Error {
-		Error::Io(error)
-	}
+    fn from(error: amd_flash::Error) -> Error {
+        Error::Io(error)
+    }
 }


### PR DESCRIPTION
Adopt a more "standard" rustfmt configuration and format. This change is purely mechanical.