### PR TITLE
rust-toolchain, .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/Cargo.lock
+/target

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2022-12-29"
+components = [ "rustfmt", "rust-src" ]

--- a/xtask/.gitignore
+++ b/xtask/.gitignore
@@ -1,0 +1,2 @@
+/Cargo.lock
+/target


### PR DESCRIPTION
Pin to a specific Rust nightly and add .gitignore files to make `git status` more useful.