### PR TITLE
xtask: add `--verbose` to various xtasks.

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -54,6 +54,8 @@ impl BuildProfile {
 #[derive(Clone, Debug)]
 struct BuildArgs {
     profile: BuildProfile,
+    locked: bool,
+    verbose: bool,
 }
 
 impl BuildArgs {
@@ -61,16 +63,18 @@ impl BuildArgs {
     /// arguments.  Debug is the default.
     fn new(matches: &clap::ArgMatches) -> BuildArgs {
         let profile = BuildProfile::new(matches);
-        BuildArgs { profile }
+        let locked = matches.get_flag("locked");
+        let verbose = matches.get_flag("verbose");
+        BuildArgs { profile, locked, verbose }
     }
 }
 
 fn main() {
     let matches = parse_args();
     match matches.subcommand() {
-        Some(("build", m)) => build(BuildArgs::new(m), m.get_flag("locked")),
-        Some(("test", m)) => test(BuildArgs::new(m), m.get_flag("locked")),
-        Some(("tests", m)) => tests(BuildArgs::new(m), m.get_flag("locked")),
+        Some(("build", m)) => build(BuildArgs::new(m)),
+        Some(("test", m)) => test(BuildArgs::new(m)),
+        Some(("tests", m)) => tests(BuildArgs::new(m)),
         Some(("expand", _m)) => expand(),
         Some(("clippy", m)) => clippy(m.get_flag("locked")),
         Some(("clean", _m)) => clean(),
@@ -90,6 +94,7 @@ fn parse_args() -> clap::ArgMatches {
         .subcommand(
             clap::Command::new("build").about("Builds").args(&[
                 clap::arg!(--locked "Build locked to Cargo.lock"),
+                clap::arg!(--verbose "Build verbosely"),
                 clap::arg!(--release "Build optimized version")
                     .conflicts_with("debug"),
                 clap::arg!(--debug "Build debug version (default)")
@@ -99,6 +104,7 @@ fn parse_args() -> clap::ArgMatches {
         .subcommand(
             clap::Command::new("test").about("Run unit tests").args(&[
                 clap::arg!(--locked "Build or test locked to Cargo.lock"),
+                clap::arg!(--verbose "Build verbosely"),
                 clap::arg!(--release "Test optimized version")
                     .conflicts_with("debug"),
                 clap::arg!(--debug "Test debug version (default)")
@@ -108,6 +114,7 @@ fn parse_args() -> clap::ArgMatches {
         .subcommand(
             clap::Command::new("tests").about("Run system tests").args(&[
                 clap::arg!(--locked "Build or test locked to Cargo.lock"),
+                clap::arg!(--verbose "Build verbosely"),
                 clap::arg!(--release "Test optimized version")
                     .conflicts_with("debug"),
                 clap::arg!(--debug "Test debug version (default)")
@@ -125,38 +132,41 @@ fn parse_args() -> clap::ArgMatches {
 }
 
 /// Runs a cross-compiled build.
-fn build(args: BuildArgs, with_locked: bool) {
+fn build(args: BuildArgs) {
     let build_type = args.profile.build_type().unwrap_or("");
-    let locked = with_locked.then_some("--locked").unwrap_or("");
-    let args = format!("build {locked} {build_type}");
+    let locked = args.locked.then_some("--locked").unwrap_or("");
+    let verbose = args.verbose.then_some("--verbose").unwrap_or("");
+    let args = format!("build {locked} {verbose} {build_type}");
     cmd(cargo(), args.split_whitespace()).run().expect("build successful");
 }
 
 /// Runs unit tests.
-fn test(args: BuildArgs, with_locked: bool) {
+fn test(args: BuildArgs) {
     let build_type = args.profile.build_type().unwrap_or("");
-    let locked = with_locked.then_some("--locked").unwrap_or("");
-    let args = format!("test {locked} {build_type}");
+    let locked = args.locked.then_some("--locked").unwrap_or("");
+    let verbose = args.verbose.then_some("--verbose").unwrap_or("");
+    let args = format!("test {locked} {verbose} {build_type}");
     cmd(cargo(), args.split_whitespace()).run().expect("test successful");
 }
 
 /// Runs system tests.
-fn tests(args: BuildArgs, with_locked: bool) {
+fn tests(args: BuildArgs) {
     let build_type = args.profile.build_type().unwrap_or("");
-    let locked = with_locked.then_some("--locked").unwrap_or("");
-    let args = format!("test {locked} {build_type}");
+    let locked = args.locked.then_some("--locked").unwrap_or("");
+    let verbose = args.verbose.then_some("--verbose").unwrap_or("");
+    let args = format!("test {locked} {build_type} {verbose}");
     cmd(cargo(), args.split_whitespace()).run().expect("test successful");
-    let args = format!("test {locked} {build_type} --features serde");
+    let args = format!("test {locked} {build_type} {verbose} --features serde");
     cmd(cargo(), args.split_whitespace()).run().expect("test successful");
-    let args = format!("test {locked} {build_type} --features serde,schemars");
+    let args = format!(
+        "test {locked} {build_type} {verbose} --features serde,schemars"
+    );
     cmd(cargo(), args.split_whitespace()).run().expect("test successful");
 }
 
 /// Expands macros.
 fn expand() {
-    cmd!(cargo(), "rustc", "--", "-Zunpretty=expanded")
-        .run()
-        .expect("expand successful");
+    cmd!(cargo(), "expand").run().expect("expand successful");
 }
 
 /// Runs the Clippy linter.


### PR DESCRIPTION
Make it so that `cargo xtask <cmd> --verbose` works for build, test, and tests.