### PR TITLE
Cargo: Make schemars and strum no_std.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2018"
 
 [dependencies]
 amd-flash = { git = "ssh://git@github.com/oxidecomputer/amd-flash.git", tag = "v0.2.0" }
-byteorder = "1.4.3"
+byteorder = { version = "1.4.3", default-features = false }
 fletcher = "0.1.0"
-modular-bitfield = "0.11.2"
+modular-bitfield = { version = "0.11.2", default-features = false }
 
 #
 # In order to use macros as discriminants in enums that make use of derive
@@ -21,14 +21,14 @@ modular-bitfield = "0.11.2"
 num-derive = { version = "0.3.0", features = [ "full-syntax" ] }
 num-traits = { version = "0.2.12", default-features = false }
 paste = "1.0"
-schemars = "0.8.8"
+schemars = { version = "0.8.8", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-strum = "0.23"
-strum_macros = "0.23.1"
+strum = { version = "0.23", default-features = false, features = [] }
+strum_macros = { version = "0.23.1" }
 zerocopy = "0.6"
 
 [features]
 default = []
 std = []
 serde = []
-schemars = ["std", "serde"]
+schemars = ["std", "serde", "dep:schemars"]


### PR DESCRIPTION
Fixes <https://github.com/oxidecomputer/amd-efs/issues/66>.