### PR TITLE
ondisk: SpiReadMode: Make serde aliases clearer for variants Normal33…

### DIFF
--- a/src/ondisk.rs
+++ b/src/ondisk.rs
@@ -51,7 +51,7 @@ pub const EFH_POSITION: [Location; 6] =
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub enum SpiReadMode {
-    #[cfg_attr(feature = "serde", serde(alias = "Normal 33.33 MHz"))]
+    #[cfg_attr(feature = "serde", serde(alias = "Normal up to 33.33 MHz"))]
     Normal33_33Mhz = 0b000, // up to 33.33 MHz
     /// First digit of name: number of lines (bits) for the command
     /// Second digit of name: number of lines (bits) for the address
@@ -69,7 +69,7 @@ pub enum SpiReadMode {
     /// Second digit: number of lines (bits) for the address
     /// Third digit: number of lines (bits) for the data
     Quad144 = 0b101,
-    #[cfg_attr(feature = "serde", serde(alias = "Normal 66.66 MHz"))]
+    #[cfg_attr(feature = "serde", serde(alias = "Normal up to 66.66 MHz"))]
     Normal66_66Mhz = 0b110, // up to 66.66 MHz
     Fast = 0b111,
     DoNothing = 0xff,


### PR DESCRIPTION
…_33Mhz, Normal66_66Mhz.

Fixes <https://github.com/oxidecomputer/amd-efs/issues/68>.