### PR TITLE
efs: Fix clippy lint.

### DIFF
--- a/src/efs.rs
+++ b/src/efs.rs
@@ -71,7 +71,7 @@ impl<
         size_of::<MainHeader>()
             .checked_add(
                 size_of::<Item>()
-                    .checked_mul(total_entries as usize)
+                    .checked_mul(total_entries)
                     .ok_or(Error::DirectoryRangeCheck)?,
             )
             .ok_or(Error::DirectoryRangeCheck)


### PR DESCRIPTION
Fixes <https://github.com/oxidecomputer/amd-efs/issues/74>.