### PR TITLE
Allow user to convert *DirectoryEntryType from/to String.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amd-efs"
-version = "0.2.6"
+version = "0.2.7"
 authors = ["Oxide Computer Company"]
 edition = "2018"
 

--- a/src/ondisk.rs
+++ b/src/ondisk.rs
@@ -777,7 +777,16 @@ impl core::fmt::Debug for PspDirectoryHeader {
 }
 
 #[repr(u8)]
-#[derive(Debug, PartialEq, FromPrimitive, Clone, Copy, BitfieldSpecifier)]
+#[derive(
+    Debug,
+    PartialEq,
+    FromPrimitive,
+    Clone,
+    Copy,
+    BitfieldSpecifier,
+    EnumString,
+    strum_macros::Display,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[bits = 8]
@@ -1248,7 +1257,16 @@ impl core::fmt::Debug for BhdDirectoryHeader {
 }
 
 #[repr(u8)]
-#[derive(Debug, PartialEq, FromPrimitive, Clone, Copy, BitfieldSpecifier)]
+#[derive(
+    Debug,
+    PartialEq,
+    FromPrimitive,
+    Clone,
+    Copy,
+    BitfieldSpecifier,
+    EnumString,
+    strum_macros::Display,
+)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[bits = 8]


### PR DESCRIPTION
Fixes <https://github.com/oxidecomputer/amd-efs/issues/88>.