### PR TITLE
Mark Efs::efh private.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amd-efs"
-version = "0.2.7"
+version = "0.3.0"
 authors = ["Oxide Computer Company"]
 edition = "2018"
 

--- a/src/efs.rs
+++ b/src/efs.rs
@@ -363,7 +363,7 @@ pub const fn preferred_efh_location(
 pub struct Efs<'a, T: FlashRead + FlashWrite> {
     storage: &'a T,
     efh_beginning: ErasableLocation,
-    pub efh: Efh,
+    efh: Efh,
     amd_physical_mode_mmio_size: Option<u32>,
 }
 


### PR DESCRIPTION
Fixes <https://github.com/oxidecomputer/amd-efs/issues/90>.