### PR TITLE
ondisk: Implement Clone for *SpiMode.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amd-efs"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Oxide Computer Company"]
 edition = "2018"
 

--- a/src/ondisk.rs
+++ b/src/ondisk.rs
@@ -259,12 +259,14 @@ pub enum ProcessorGeneration {
 
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[derive(Clone)]
 pub struct EfhBulldozerSpiMode {
     pub read_mode: SpiReadMode,
     pub fast_speed_new: SpiFastSpeedNew,
 }
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[derive(Clone)]
 pub struct EfhNaplesSpiMode {
     pub read_mode: SpiReadMode,
     pub fast_speed_new: SpiFastSpeedNew,
@@ -273,6 +275,7 @@ pub struct EfhNaplesSpiMode {
 
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[derive(Clone)]
 pub struct EfhRomeSpiMode {
     pub read_mode: SpiReadMode,
     pub fast_speed_new: SpiFastSpeedNew,


### PR DESCRIPTION
Fixes <https://github.com/oxidecomputer/amd-efs/issues/95>.