### PR TITLE
Merge amd-flash contents into amd-efs.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-amd-flash = { git = "ssh://git@github.com/oxidecomputer/amd-flash.git", tag = "v0.2.1" }
 byteorder = { version = "1.4.3", default-features = false }
 fletcher = "0.1.0"
 modular-bitfield = { version = "0.11.2", default-features = false }
@@ -31,6 +30,6 @@ memoffset = "0.5"
 
 [features]
 default = []
-std = ["thiserror", "amd-flash/std"]
+std = ["thiserror"]
 serde = []
 schemars = ["std", "serde", "dep:schemars"]

--- a/src/adapters.rs
+++ b/src/adapters.rs
@@ -1,8 +1,9 @@
-use amd_flash::ErasableLocation;
-use amd_flash::FlashAlign;
-use amd_flash::FlashRead;
-use amd_flash::FlashWrite;
-use amd_flash::Result;
+use crate::flash;
+use flash::ErasableLocation;
+use flash::FlashAlign;
+use flash::FlashRead;
+use flash::FlashWrite;
+use flash::Result;
 
 const UPPER_HALF_OFFSET: u32 = 0x100_0000; // 16 MiB
 const MODULUS: u32 = 0x200_0000; // 32 MiB
@@ -31,24 +32,22 @@ impl FlashWrite for Upper16MiBFlashAdapter<'_> {
     fn erase_block(
         &self,
         offset: ErasableLocation,
-    ) -> core::result::Result<(), amd_flash::Error> {
+    ) -> core::result::Result<(), flash::Error> {
         let offset = self.location(offset)?;
         let offset = (offset + UPPER_HALF_OFFSET) % MODULUS;
         self.underlying_writer.erase_block(
-            self.erasable_location(offset)
-                .ok_or(amd_flash::Error::Alignment)?,
+            self.erasable_location(offset).ok_or(flash::Error::Alignment)?,
         )
     }
     fn erase_and_write_block(
         &self,
         offset: ErasableLocation,
         buf: &[u8],
-    ) -> core::result::Result<(), amd_flash::Error> {
+    ) -> core::result::Result<(), flash::Error> {
         let offset = self.location(offset)?;
         let offset = (offset + UPPER_HALF_OFFSET) % MODULUS;
         self.underlying_writer.erase_and_write_block(
-            self.erasable_location(offset)
-                .ok_or(amd_flash::Error::Alignment)?,
+            self.erasable_location(offset).ok_or(flash::Error::Alignment)?,
             buf,
         )
     }

--- a/src/allocators.rs
+++ b/src/allocators.rs
@@ -1,0 +1,137 @@
+use crate::flash::{ErasableRange, Location};
+use crate::flash::{Error, Result};
+
+pub trait FlashAllocate {
+    fn take_at_least(&mut self, size: usize) -> Option<ErasableRange>;
+    fn max_contiguous_capacity(&self) -> usize;
+}
+
+pub struct ArenaFlashAllocator {
+    _efh_range: ErasableRange,
+    free_ranges: [ErasableRange; 2],
+}
+
+impl ArenaFlashAllocator {
+    /// Creates a new allocator that will use parts of the given ARENA.
+    /// Depending on processor generation, a part of it will be cut out
+    /// and not given to the user (since it needs to be at a fixed
+    /// spot and also is used by us).
+    pub fn new(
+        efh_beginning: Location,
+        efh_size: usize,
+        arena: ErasableRange,
+    ) -> Result<Self> {
+        let mut arena = arena;
+        assert!(Location::from(arena.beginning) == 0);
+        // Avoid EFH_BEGINNING..(EFH_BEGINNING + EFH_SIZE)
+        let a_size = efh_beginning as usize;
+        let a = arena.take_at_least(a_size).ok_or(Error::Size)?;
+        assert!(Location::from(a.end) as usize == a_size);
+        let _efh_range = arena.take_at_least(efh_size).ok_or(Error::Size)?;
+        Ok(Self { _efh_range, free_ranges: [a, arena] })
+    }
+}
+impl FlashAllocate for ArenaFlashAllocator {
+    /// From the free ranges, take a range of at least SIZE Bytes,
+    /// if possible. Otherwise return None.
+    fn take_at_least(&mut self, size: usize) -> Option<ErasableRange> {
+        self.free_ranges[0]
+            .take_at_least(size)
+            .or_else(|| self.free_ranges[1].take_at_least(size))
+    }
+    fn max_contiguous_capacity(&self) -> usize {
+        let mut max_capacity = 0usize;
+        for range in &self.free_ranges {
+            let capacity = range.capacity();
+            if capacity > max_capacity {
+                max_capacity = capacity
+            }
+        }
+        max_capacity
+    }
+}
+
+#[cfg(test)]
+mod allocator_tests {
+    use super::*;
+    use crate::flash::FlashAlign;
+    fn intersect(
+        a: &ErasableRange,
+        b: &ErasableRange,
+    ) -> Option<(Location, Location)> {
+        let new_beginning =
+            Location::from(a.beginning).max(Location::from(b.beginning));
+        let new_end = Location::from(a.end).min(Location::from(b.end));
+        if new_beginning < new_end {
+            Some((new_beginning, new_end))
+        } else {
+            None
+        }
+    }
+    struct Buffer {}
+    impl FlashAlign for Buffer {
+        fn erasable_block_size(&self) -> usize {
+            4
+        }
+    }
+    impl Buffer {
+        fn allocator(&self) -> ArenaFlashAllocator {
+            let beginning = self.erasable_location(0).unwrap();
+            let end = beginning.advance_at_least(0x4_0000).unwrap();
+            ArenaFlashAllocator::new(
+                0x2_0000,
+                0x200,
+                ErasableRange::new(beginning, end),
+            )
+            .unwrap()
+        }
+        fn efh_range(&self) -> ErasableRange {
+            ErasableRange::new(
+                self.erasable_location(0x2_0000).unwrap(),
+                self.erasable_location(0x2_0000)
+                    .unwrap()
+                    .advance_at_least(0x200)
+                    .unwrap(),
+            )
+        }
+    }
+    #[test]
+    fn test_allocator_1() {
+        let buf = Buffer {};
+        let mut allocator = buf.allocator();
+        let efh_range = buf.efh_range();
+        let a = allocator.take_at_least(42).unwrap();
+        let b = allocator.take_at_least(100).unwrap();
+        assert!(intersect(&a, &b).is_none());
+        assert!(intersect(&a, &efh_range).is_none());
+        assert!(intersect(&b, &efh_range).is_none());
+        assert!(Location::from(b.end) < 0x2_0000);
+    }
+
+    #[test]
+    fn test_allocator_2() {
+        let buf = Buffer {};
+        let mut allocator = buf.allocator();
+        let efh_range = buf.efh_range();
+        let a = allocator.take_at_least(0x2_0000).unwrap();
+        let b = allocator.take_at_least(100).unwrap();
+        assert!(intersect(&a, &b).is_none());
+        assert!(intersect(&a, &efh_range).is_none());
+        assert!(intersect(&b, &efh_range).is_none());
+        assert!(Location::from(b.end) < 0x4_0000);
+    }
+
+    #[test]
+    fn test_allocator_3() {
+        let buf = Buffer {};
+        let mut allocator = buf.allocator();
+        let efh_range = buf.efh_range();
+        let a = allocator.take_at_least(0x1_fff8).unwrap();
+        let b = allocator.take_at_least(100).unwrap();
+        assert!(intersect(&a, &b).is_none());
+        assert!(intersect(&a, &efh_range).is_none());
+        assert!(intersect(&b, &efh_range).is_none());
+        assert!(Location::from(b.end) < 0x4_0000);
+        assert!(Location::from(b.beginning) > 0x2_0000);
+    }
+}

--- a/src/efs.rs
+++ b/src/efs.rs
@@ -1,4 +1,5 @@
 use crate::amdfletcher32::AmdFletcher32;
+use crate::flash;
 use crate::ondisk::header_from_collection;
 use crate::ondisk::header_from_collection_mut;
 #[cfg(feature = "std")]
@@ -17,11 +18,11 @@ use crate::ondisk::{
 use crate::types::Error;
 use crate::types::Result;
 
-#[cfg(feature = "std")]
-use amd_flash::ErasableRange;
-use amd_flash::{ErasableLocation, FlashRead, FlashWrite, Location};
 use core::convert::TryInto;
 use core::mem::size_of;
+#[cfg(feature = "std")]
+use flash::ErasableRange;
+use flash::{ErasableLocation, FlashRead, FlashWrite, Location};
 use zerocopy::AsBytes;
 use zerocopy::FromBytes;
 
@@ -989,13 +990,14 @@ impl<'a, T: FlashRead + FlashWrite> Efs<'a, T> {
 #[cfg(test)]
 mod tests {
     use super::{EfhBulldozerSpiMode, EfhNaplesSpiMode, EfhRomeSpiMode};
+    use crate::flash;
     use crate::ondisk::{
         SpiFastSpeedNew, SpiNaplesMicronMode, SpiReadMode, SpiRomeMicronMode,
     };
     use crate::Efh;
     use crate::Efs;
     use crate::Error;
-    use amd_flash::{ErasableLocation, FlashAlign, FlashRead, FlashWrite};
+    use flash::{ErasableLocation, FlashAlign, FlashRead, FlashWrite};
 
     struct Storage {}
     impl FlashAlign for Storage {
@@ -1008,7 +1010,7 @@ mod tests {
             &self,
             _: u32,
             _: &mut [u8],
-        ) -> core::result::Result<(), amd_flash::Error> {
+        ) -> core::result::Result<(), flash::Error> {
             todo!()
         }
     }
@@ -1016,14 +1018,14 @@ mod tests {
         fn erase_block(
             &self,
             _: ErasableLocation,
-        ) -> core::result::Result<(), amd_flash::Error> {
+        ) -> core::result::Result<(), flash::Error> {
             todo!()
         }
         fn erase_and_write_block(
             &self,
             _: ErasableLocation,
             _: &[u8],
-        ) -> core::result::Result<(), amd_flash::Error> {
+        ) -> core::result::Result<(), flash::Error> {
             todo!()
         }
     }

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -1,0 +1,290 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use core::convert::TryInto;
+
+#[derive(Debug)]
+#[cfg_attr(feature = "std", derive(thiserror::Error))]
+pub enum Error {
+    #[cfg_attr(feature = "std", error("io"))]
+    Io,
+    #[cfg_attr(
+        feature = "std",
+        error("alignment is not good enough for erasability of block")
+    )]
+    Alignment,
+    #[cfg_attr(feature = "std", error("programmer violated an invariant"))]
+    Programmer,
+    #[cfg_attr(
+        feature = "std",
+        error("no area of requested size is available")
+    )]
+    Size,
+}
+
+pub type Result<Q> = core::result::Result<Q, Error>;
+
+/// This is any Location on the Flash chip
+pub type Location = u32;
+
+/// This is a Location which definitely is aligned on an erase block boundary
+#[derive(Clone, Copy, Debug)]
+pub struct ErasableLocation {
+    location: Location,
+    erasable_block_size: usize,
+}
+
+impl ErasableLocation {
+    pub fn erasable_block_size(&self) -> usize {
+        self.erasable_block_size
+    }
+    pub fn erasable_block_mask(&self) -> u32 {
+        (self.erasable_block_size as u32) - 1
+    }
+    /// Note: Assumed beginning <= self, otherwise result will be 0.
+    pub fn extent(beginning: Self, end: Self) -> u32 {
+        let beginning = beginning.location;
+        let end = end.location;
+        end.saturating_sub(beginning)
+    }
+    pub fn advance(&self, amount: usize) -> Result<Self> {
+        if amount & (self.erasable_block_mask() as usize) != 0 {
+            return Err(Error::Alignment);
+        }
+        let pos = (self.location as usize)
+            .checked_add(amount)
+            .ok_or(Error::Alignment)?;
+        Ok(Self {
+            location: pos.try_into().map_err(|_| Error::Alignment)?,
+            erasable_block_size: self.erasable_block_size,
+        })
+    }
+    pub fn advance_at_least(&self, amount: usize) -> Result<Self> {
+        // Round up to a multiple of erasable_block_size()
+        let diff =
+            0usize.wrapping_sub(amount) & (self.erasable_block_mask() as usize);
+        let amount = amount.checked_add(diff).ok_or(Error::Alignment)?;
+        self.advance(amount)
+    }
+}
+
+impl From<ErasableLocation> for Location {
+    fn from(source: ErasableLocation) -> Self {
+        source.location
+    }
+}
+
+#[derive(Debug)]
+pub struct ErasableRange {
+    pub beginning: ErasableLocation, // note: same erasable_block_size assumed
+    pub end: ErasableLocation,       // note: same erasable_block_size assumed
+}
+impl ErasableRange {
+    pub fn new(beginning: ErasableLocation, end: ErasableLocation) -> Self {
+        assert!(Location::from(beginning) <= Location::from(end)); // TODO nicer
+        Self { beginning, end }
+    }
+    /// Splits the Range after at least SIZE Byte, if possible.
+    /// Return the first part. Retain the second part.
+    pub fn take_at_least(&mut self, size: usize) -> Option<Self> {
+        let x_beginning = self.beginning;
+        let x_end = self.beginning.advance_at_least(size).ok()?;
+        if Location::from(x_end) <= Location::from(self.end) {
+            *self = Self::new(x_end, self.end);
+            Some(Self::new(x_beginning, x_end))
+        } else {
+            None
+        }
+    }
+    /// in Byte
+    pub fn capacity(&self) -> usize {
+        ErasableLocation::extent(self.beginning, self.end) as usize
+    }
+}
+
+pub trait FlashRead {
+    /// Read exactly the right amount from the location BEGINNING to fill the
+    /// entire BUFFER that was passed.
+    fn read_exact(&self, beginning: Location, buffer: &mut [u8]) -> Result<()>;
+}
+
+pub trait FlashAlign {
+    /// Note: Assumed constant for lifetime of instance.
+    /// Note: Assumed to be a power of two.
+    fn erasable_block_size(&self) -> usize;
+    fn erasable_block_mask(&self) -> u32 {
+        (self.erasable_block_size() as u32) - 1
+    }
+    fn is_aligned(&self, location: Location) -> bool {
+        (location & self.erasable_block_mask()) == 0
+    }
+    /// Determine an erasable location, given a location, if possible.
+    /// If not possible, return None.
+    fn erasable_location(
+        &self,
+        location: Location,
+    ) -> Option<ErasableLocation> {
+        let erasable_block_size = self.erasable_block_size();
+        self.is_aligned(location)
+            .then_some(ErasableLocation { location, erasable_block_size })
+    }
+    /// Given an erasable location, returns the corresponding location
+    /// IF the erasable location is compatible with our instance.
+    fn location(
+        &self,
+        erasable_location: ErasableLocation,
+    ) -> Result<Location> {
+        if erasable_location.erasable_block_size == self.erasable_block_size() {
+            Ok(erasable_location.location)
+        } else {
+            Err(Error::Alignment)
+        }
+    }
+}
+
+pub trait FlashWrite: FlashRead + FlashAlign {
+    /// Note: BUFFER.len() == erasable_block_size()
+    fn read_erasable_block(
+        &self,
+        location: ErasableLocation,
+        buffer: &mut [u8],
+    ) -> Result<()> {
+        if buffer.len() != self.erasable_block_size() {
+            return Err(Error::Programmer);
+        }
+        self.read_exact(self.location(location)?, buffer)?;
+        Ok(())
+    }
+    fn erase_block(&self, location: ErasableLocation) -> Result<()>;
+    /// Note: If BUFFER.len() < erasable_block_size(), it has to erase the
+    /// remainder anyway.
+    fn erase_and_write_block(
+        &self,
+        location: ErasableLocation,
+        buffer: &[u8],
+    ) -> Result<()>;
+
+    // FIXME: sanity check callers
+    fn erase_and_write_blocks(
+        &self,
+        location: ErasableLocation,
+        buf: &[u8],
+    ) -> Result<()> {
+        let mut location = location;
+        let erasable_block_size = self.erasable_block_size();
+        for chunk in buf.chunks(erasable_block_size) {
+            self.erase_and_write_block(location, chunk)?;
+            if chunk.len() != erasable_block_size {
+                // TODO: Only allow on last chunk
+                break;
+            }
+            location = location.advance(erasable_block_size)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::cell::RefCell;
+    const KIB: usize = 1024; // B
+    const ERASABLE_BLOCK_SIZE: usize = 128 * KIB;
+
+    struct FlashImage<'a> {
+        buf: RefCell<&'a mut [u8]>,
+        erasable_block_size: usize,
+    }
+
+    impl<'a> FlashImage<'a> {
+        pub fn new(buf: &'a mut [u8]) -> Self {
+            Self {
+                buf: RefCell::new(buf),
+                erasable_block_size: ERASABLE_BLOCK_SIZE,
+            }
+        }
+    }
+
+    impl FlashRead for FlashImage<'_> {
+        fn read_exact(
+            &self,
+            location: Location,
+            buffer: &mut [u8],
+        ) -> Result<()> {
+            let len = buffer.len();
+            let buf = self.buf.borrow();
+            let block = &buf[location as usize..];
+            let block = &block[0..len];
+            buffer[..].copy_from_slice(block);
+            Ok(())
+        }
+    }
+
+    impl FlashAlign for FlashImage<'_> {
+        fn erasable_block_size(&self) -> usize {
+            self.erasable_block_size
+        }
+    }
+    impl FlashWrite for FlashImage<'_> {
+        fn read_erasable_block(
+            &self,
+            location: ErasableLocation,
+            buffer: &mut [u8],
+        ) -> Result<()> {
+            let erasable_block_size = self.erasable_block_size();
+            let location: Location = location.into();
+            let buf = self.buf.borrow();
+            let block = &buf
+                [location as usize..(location as usize + erasable_block_size)];
+            if buffer.len() != erasable_block_size {
+                return Err(Error::Programmer);
+            }
+            buffer[..].copy_from_slice(block);
+            Ok(())
+        }
+        fn erase_block(&self, location: ErasableLocation) -> Result<()> {
+            let location: Location = location.into();
+            let mut buf = self.buf.borrow_mut();
+            let block = &mut buf[location as usize
+                ..(location as usize + self.erasable_block_size())];
+            block.fill(0xff);
+            Ok(())
+        }
+        fn erase_and_write_block(
+            &self,
+            location: ErasableLocation,
+            buffer: &[u8],
+        ) -> Result<()> {
+            let location: Location = location.into();
+            let mut buf = self.buf.borrow_mut();
+            let block = &mut buf[location as usize
+                ..(location as usize + self.erasable_block_size())];
+            block.copy_from_slice(&buffer[..]);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn flash_image_usage() -> Result<()> {
+        let mut storage = [0xFFu8; 256 * KIB];
+        let flash_image = FlashImage::new(&mut storage[..]);
+        let beginning_1 =
+            flash_image.erasable_location(Location::from(0u32)).unwrap();
+        let erasable_block_size = ERASABLE_BLOCK_SIZE;
+        flash_image
+            .erase_and_write_block(beginning_1, &[1u8; ERASABLE_BLOCK_SIZE])?;
+        let beginning_2 = flash_image
+            .erasable_location(Location::from(erasable_block_size as u32))
+            .unwrap();
+        flash_image
+            .erase_and_write_block(beginning_2, &[2u8; ERASABLE_BLOCK_SIZE])?;
+        let mut buf: [u8; ERASABLE_BLOCK_SIZE] = [0u8; ERASABLE_BLOCK_SIZE];
+        flash_image.read_exact(0, &mut buf)?;
+        assert_eq!(buf, [1u8; ERASABLE_BLOCK_SIZE]);
+        flash_image
+            .read_exact(Location::from(erasable_block_size as u32), &mut buf)?;
+        assert_eq!(buf, [2u8; ERASABLE_BLOCK_SIZE]);
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,10 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 mod adapters;
+pub mod allocators;
 mod amdfletcher32;
 mod efs;
+pub mod flash;
 mod ondisk;
 mod serializers;
 mod struct_accessors;

--- a/src/ondisk.rs
+++ b/src/ondisk.rs
@@ -1,12 +1,12 @@
 // This file contains the AMD firmware Flash on-disk format.  Please only change it in coordination with the AMD firmware team.  Even then, you probably shouldn't.
 
+use crate::flash::Location;
 use crate::struct_accessors::make_accessors;
 use crate::struct_accessors::DummyErrorChecks;
 use crate::struct_accessors::Getter;
 use crate::struct_accessors::Setter;
 use crate::types::Error;
 use crate::types::Result;
-use amd_flash::Location;
 use byteorder::LittleEndian;
 use core::convert::TryFrom;
 use core::convert::TryInto;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,8 +1,9 @@
+use crate::flash;
 #[derive(Debug)]
 #[cfg_attr(feature = "std", derive(thiserror::Error))]
 pub enum Error {
     #[cfg_attr(feature = "std", error("io {0}"))]
-    Io(amd_flash::Error),
+    Io(flash::Error),
     #[cfg_attr(feature = "std", error("efs header not found"))]
     EfsHeaderNotFound,
     #[cfg_attr(feature = "std", error("efs range check"))]
@@ -40,8 +41,8 @@ pub enum Error {
 
 pub type Result<Q> = core::result::Result<Q, Error>;
 
-impl From<amd_flash::Error> for Error {
-    fn from(error: amd_flash::Error) -> Error {
+impl From<flash::Error> for Error {
+    fn from(error: flash::Error) -> Error {
         Error::Io(error)
     }
 }


### PR DESCRIPTION
Fixes <https://github.com/oxidecomputer/amd-efs/issues/109>: Just put amd-flash's contents into modules "allocators" and "flash" inside amd-efs.