### PR TITLE
Update num-derive dependency to 0.4.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,7 @@ edition = "2021"
 byteorder = { version = "1.4.3", default-features = false }
 fletcher = "0.1.0"
 modular-bitfield = { version = "0.11.2", default-features = false }
-
-#
-# In order to use macros as discriminants in enums that make use of derive
-# macros (e.g., AsBytes, FromPrimitive), we need the syn crate to have "full"
-# enabled. The easiest way to do this is to use num-derive's "full-syntax",
-# which passes "full" through to syn.
-#
-num-derive = { version = "0.3.0", features = [ "full-syntax" ] }
+num-derive = { version = "0.4.2" }
 num-traits = { version = "0.2.12", default-features = false }
 paste = "1.0"
 schemars = { version = "0.8.8", optional = true }


### PR DESCRIPTION
Fixes <https://github.com/oxidecomputer/amd-efs/issues/115>.