### PR TITLE
Add espi configuration I/O mode bits

### DIFF
--- a/src/ondisk.rs
+++ b/src/ondisk.rs
@@ -814,6 +814,24 @@ macro_rules! make_bitfield_serde {(
     }
 }}
 
+#[derive(
+    Debug, PartialEq, Eq, FromPrimitive, Clone, Copy, BitfieldSpecifier,
+)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub enum EspiIoMode {
+    Auto = 0,
+    ForceSingle = 1,
+    ForceDual = 2,
+    ForceQuad = 3,
+}
+
+impl Default for EspiIoMode {
+    fn default() -> Self {
+        Self::Auto
+    }
+}
+
 make_bitfield_serde! {
     #[bitfield(bits = 8)]
     #[repr(u8)]
@@ -826,10 +844,7 @@ make_bitfield_serde! {
         pub data_bus || u8 : B1 | pub get u8 : pub set u8,
         pub clock || u8 : B1 | pub get u8 : pub set u8,
         pub respond_port_0x80 || bool : bool | pub get bool : pub set bool,
-        #[allow(non_snake_case)]
-        _reserved_1 || #[serde(default)] u8 : B1,
-        #[allow(non_snake_case)]
-        _reserved_2 || #[serde(default)] u8 : B1,
+        pub io_mode : EspiIoMode | pub get EspiIoMode : pub set EspiIoMode,
     }
 }
 

--- a/src/serializers.rs
+++ b/src/serializers.rs
@@ -84,8 +84,7 @@ make_serde!(
         data_bus,
         enable_port_0x80,
         respond_port_0x80,
+        io_mode,
         invalid,
-        _reserved_1,
-        _reserved_2,
     ]
 );


### PR DESCRIPTION
These two bits become the I/O mode from Genoa on.

Tested building a rubyred image with these options, and that dumping shows what I expect here:

```
% ./target/debug/amd-host-image-builder dump -i turin-rubyred-1.0.0.1-p1.img
{
  processor_generation: "Turin",
  spi_mode_bulldozer: null,
  spi_mode_zen_naples: null,
  spi_mode_zen_rome: null,
  espi0_configuration: {
    invalid: false,
    enable_port_0x80: false,
    alert_pin: 0,
    data_bus: 0,
    clock: 0,
    respond_port_0x80: false,
    io_mode: "ForceDual"
  },
```