### PR TITLE
Move macro definition of "make_bitfield_serde" to struct_accessors.

### DIFF
--- a/src/ondisk.rs
+++ b/src/ondisk.rs
@@ -4,6 +4,7 @@ use crate::flash::Location;
 use crate::struct_accessors::Getter;
 use crate::struct_accessors::Setter;
 use crate::struct_accessors::make_accessors;
+use crate::struct_accessors::make_bitfield_serde;
 use crate::types::Error;
 use crate::types::Result;
 use core::convert::TryFrom;
@@ -750,95 +751,6 @@ impl ValueOrLocation {
         }
     }
 }
-
-// XXX: If I move this to struct_accessors, it doesn't work anymore.
-
-/// A variant of the make_accessors macro for modular_bitfields.
-macro_rules! make_bitfield_serde {(
-    $(#[$struct_meta:meta])*
-    $struct_vis:vis
-    struct $StructName:ident {
-        $(
-            $(#[$field_meta:meta])*
-            $field_vis:vis
-            $field_name:ident
-            $(|| $(#[$serde_field_orig_meta:meta])* $serde_ty:ty : $field_orig_ty:ty)?
-            $(: $field_ty:ty)?
-            $(| $getter_vis:vis get $field_user_ty:ty $(: $setter_vis:vis set $field_setter_user_ty:ty)?)?
-        ),* $(,)?
-    }
-) => {
-    $(#[$struct_meta])*
-    $struct_vis
-    struct $StructName {
-        $(
-            $(#[$field_meta])*
-            $field_vis
-            $($field_name : $field_ty,)?
-            $($field_name : $field_orig_ty,)?
-        )*
-    }
-
-    impl $StructName {
-        pub fn builder() -> Self {
-            Self::new() // NOT default
-        }
-        pub fn build(&self) -> Self {
-            self.clone()
-        }
-    }
-
-    #[cfg(feature = "serde")]
-    #[allow(dead_code)]
-    impl $StructName {
-        $(
-            paste::paste!{
-                $(
-                    #[allow(non_snake_case)]
-                    pub(crate) fn [<serde_ $field_name>] (self : &'_ Self)
-                        -> Result<$field_ty> {
-                        Ok(self.$field_name())
-                    }
-                )?
-                $(
-                    #[allow(non_snake_case)]
-                    pub(crate) fn [<serde_ $field_name>] (self : &'_ Self)
-                        -> Result<$serde_ty> {
-                        Ok(self.$field_name().into())
-                    }
-                )?
-                $(
-                    #[allow(non_snake_case)]
-                    pub(crate) fn [<serde_with_ $field_name>](self : &mut Self, value: $field_ty) -> &mut Self {
-                        self.[<set_ $field_name>](value.into());
-                        self
-                    }
-                )?
-                $(
-                    #[allow(non_snake_case)]
-                    pub(crate) fn [<serde_with_ $field_name>](self : &mut Self, value: $serde_ty) -> &mut Self {
-                        self.[<set_ $field_name>](value.into());
-                        self
-                    }
-                )?
-            }
-        )*
-    }
-
-    #[cfg(feature = "serde")]
-    paste::paste! {
-        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-        #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
-        #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-        #[cfg_attr(feature = "serde", serde(rename = "" $StructName))]
-        pub(crate) struct [<Serde $StructName>] {
-            $(
-                $(pub $field_name : <$field_ty as Specifier>::InOut,)?
-                $($(#[$serde_field_orig_meta])* pub $field_name : $serde_ty,)?
-            )*
-        }
-    }
-}}
 
 #[derive(
     Debug, PartialEq, Eq, FromPrimitive, Clone, Copy, BitfieldSpecifier,

--- a/src/struct_accessors.rs
+++ b/src/struct_accessors.rs
@@ -315,3 +315,92 @@ macro_rules! make_accessors {(
 )}
 
 pub(crate) use make_accessors;
+
+/// A variant of the make_accessors macro for modular_bitfields.
+macro_rules! make_bitfield_serde {(
+    $(#[$struct_meta:meta])*
+    $struct_vis:vis
+    struct $StructName:ident {
+        $(
+            $(#[$field_meta:meta])*
+            $field_vis:vis
+            $field_name:ident
+            $(|| $(#[$serde_field_orig_meta:meta])* $serde_ty:ty : $field_orig_ty:ty)?
+            $(: $field_ty:ty)?
+            $(| $getter_vis:vis get $field_user_ty:ty $(: $setter_vis:vis set $field_setter_user_ty:ty)?)?
+        ),* $(,)?
+    }
+) => {
+    $(#[$struct_meta])*
+    $struct_vis
+    struct $StructName {
+        $(
+            $(#[$field_meta])*
+            $field_vis
+            $($field_name : $field_ty,)?
+            $($field_name : $field_orig_ty,)?
+        )*
+    }
+
+    impl $StructName {
+        pub fn builder() -> Self {
+            Self::new() // NOT default
+        }
+        pub fn build(&self) -> Self {
+            self.clone()
+        }
+    }
+
+    #[cfg(feature = "serde")]
+    #[allow(dead_code)]
+    impl $StructName {
+        $(
+            paste::paste!{
+                $(
+                    #[allow(non_snake_case)]
+                    pub(crate) fn [<serde_ $field_name>] (self : &'_ Self)
+                        -> Result<$field_ty> {
+                        Ok(self.$field_name())
+                    }
+                )?
+                $(
+                    #[allow(non_snake_case)]
+                    pub(crate) fn [<serde_ $field_name>] (self : &'_ Self)
+                        -> Result<$serde_ty> {
+                        Ok(self.$field_name().into())
+                    }
+                )?
+                $(
+                    #[allow(non_snake_case)]
+                    pub(crate) fn [<serde_with_ $field_name>](self : &mut Self, value: $field_ty) -> &mut Self {
+                        self.[<set_ $field_name>](value.into());
+                        self
+                    }
+                )?
+                $(
+                    #[allow(non_snake_case)]
+                    pub(crate) fn [<serde_with_ $field_name>](self : &mut Self, value: $serde_ty) -> &mut Self {
+                        self.[<set_ $field_name>](value.into());
+                        self
+                    }
+                )?
+            }
+        )*
+    }
+
+    #[cfg(feature = "serde")]
+    paste::paste! {
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+        #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
+        #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+        #[cfg_attr(feature = "serde", serde(rename = "" $StructName))]
+        pub(crate) struct [<Serde $StructName>] {
+            $(
+                $(pub $field_name : <$field_ty as Specifier>::InOut,)?
+                $($(#[$serde_field_orig_meta])* pub $field_name : $serde_ty,)?
+            )*
+        }
+    }
+}}
+
+pub(crate) use make_bitfield_serde;


### PR DESCRIPTION
Fixes <https://github.com/oxidecomputer/amd-efs/issues/124>.